### PR TITLE
Simplified and more bound-friendly IntoLender; Lend help type

### DIFF
--- a/src/adapters/chain.rs
+++ b/src/adapters/chain.rs
@@ -12,7 +12,9 @@ pub struct Chain<A, B> {
     b: Fuse<B>,
 }
 impl<A, B> Chain<A, B> {
-    pub(crate) fn new(a: A, b: B) -> Self { Self { a: Fuse::new(a), b: Fuse::new(b) } }
+    pub(crate) fn new(a: A, b: B) -> Self {
+        Self { a: Fuse::new(a), b: Fuse::new(b) }
+    }
 }
 impl<'lend, A, B> Lending<'lend> for Chain<A, B>
 where
@@ -26,9 +28,13 @@ where
     A: Lender,
     B: Lender + for<'all> Lending<'all, Lend = <A as Lending<'all>>::Lend>,
 {
-    fn next(&mut self) -> Option<<Self as Lending<'_>>::Lend> { self.a.next().or_else(|| self.b.next()) }
+    fn next(&mut self) -> Option<<Self as Lending<'_>>::Lend> {
+        self.a.next().or_else(|| self.b.next())
+    }
     #[inline]
-    fn count(self) -> usize { self.a.count() + self.b.count() }
+    fn count(self) -> usize {
+        self.a.count() + self.b.count()
+    }
     fn try_fold<Acc, F, R>(&mut self, mut acc: Acc, mut f: F) -> R
     where
         Self: Sized,
@@ -106,7 +112,9 @@ where
     B: DoubleEndedLender + for<'all> Lending<'all, Lend = <A as Lending<'all>>::Lend>,
 {
     #[inline]
-    fn next_back(&mut self) -> Option<<Self as Lending<'_>>::Lend> { self.b.next_back().or_else(|| self.a.next_back()) }
+    fn next_back(&mut self) -> Option<<Self as Lending<'_>>::Lend> {
+        self.b.next_back().or_else(|| self.a.next_back())
+    }
 
     #[inline]
     fn advance_back_by(&mut self, n: usize) -> Result<(), NonZeroUsize> {
@@ -170,5 +178,7 @@ where
 {
 }
 impl<A: Default, B: Default> Default for Chain<A, B> {
-    fn default() -> Self { Chain::new(Default::default(), Default::default()) }
+    fn default() -> Self {
+        Chain::new(Default::default(), Default::default())
+    }
 }

--- a/src/adapters/chunk.rs
+++ b/src/adapters/chunk.rs
@@ -7,7 +7,9 @@ pub struct Chunk<'s, T> {
     len: usize,
 }
 impl<'s, T> Chunk<'s, T> {
-    pub(crate) fn new(lender: &'s mut T, len: usize) -> Self { Self { lender, len } }
+    pub(crate) fn new(lender: &'s mut T, len: usize) -> Self {
+        Self { lender, len }
+    }
 }
 impl<'lend, 's, T> Lending<'lend> for Chunk<'s, T>
 where

--- a/src/adapters/cloned.rs
+++ b/src/adapters/cloned.rs
@@ -8,7 +8,9 @@ pub struct Cloned<L> {
     lender: L,
 }
 impl<L> Cloned<L> {
-    pub(crate) fn new(lender: L) -> Cloned<L> { Cloned { lender } }
+    pub(crate) fn new(lender: L) -> Cloned<L> {
+        Cloned { lender }
+    }
 }
 impl<T, L> Iterator for Cloned<L>
 where
@@ -18,9 +20,13 @@ where
 {
     type Item = T;
     #[inline]
-    fn next(&mut self) -> Option<Self::Item> { self.lender.next().cloned() }
+    fn next(&mut self) -> Option<Self::Item> {
+        self.lender.next().cloned()
+    }
     #[inline]
-    fn size_hint(&self) -> (usize, Option<usize>) { self.lender.size_hint() }
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.lender.size_hint()
+    }
 }
 impl<T, L> DoubleEndedIterator for Cloned<L>
 where
@@ -29,7 +35,9 @@ where
     L: for<'all> Lending<'all, Lend = &'all T>,
 {
     #[inline]
-    fn next_back(&mut self) -> Option<Self::Item> { self.lender.next_back().cloned() }
+    fn next_back(&mut self) -> Option<Self::Item> {
+        self.lender.next_back().cloned()
+    }
 }
 impl<T, L> ExactSizeIterator for Cloned<L>
 where
@@ -37,7 +45,9 @@ where
     T: Clone,
     L: for<'all> Lending<'all, Lend = &'all T>,
 {
-    fn len(&self) -> usize { self.lender.len() }
+    fn len(&self) -> usize {
+        self.lender.len()
+    }
 }
 impl<T, L> FusedIterator for Cloned<L>
 where
@@ -50,5 +60,7 @@ impl<L> Default for Cloned<L>
 where
     L: Default,
 {
-    fn default() -> Self { Self::new(L::default()) }
+    fn default() -> Self {
+        Self::new(L::default())
+    }
 }

--- a/src/adapters/copied.rs
+++ b/src/adapters/copied.rs
@@ -8,7 +8,9 @@ pub struct Copied<L> {
     lender: L,
 }
 impl<L> Copied<L> {
-    pub(crate) fn new(lender: L) -> Copied<L> { Copied { lender } }
+    pub(crate) fn new(lender: L) -> Copied<L> {
+        Copied { lender }
+    }
 }
 impl<T, L> Iterator for Copied<L>
 where
@@ -18,9 +20,13 @@ where
 {
     type Item = T;
     #[inline]
-    fn next(&mut self) -> Option<Self::Item> { self.lender.next().copied() }
+    fn next(&mut self) -> Option<Self::Item> {
+        self.lender.next().copied()
+    }
     #[inline]
-    fn size_hint(&self) -> (usize, Option<usize>) { self.lender.size_hint() }
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.lender.size_hint()
+    }
 }
 impl<T, L> DoubleEndedIterator for Copied<L>
 where
@@ -29,7 +35,9 @@ where
     L: for<'all> Lending<'all, Lend = &'all T>,
 {
     #[inline]
-    fn next_back(&mut self) -> Option<Self::Item> { self.lender.next_back().copied() }
+    fn next_back(&mut self) -> Option<Self::Item> {
+        self.lender.next_back().copied()
+    }
 }
 impl<T, L> ExactSizeIterator for Copied<L>
 where
@@ -37,7 +45,9 @@ where
     T: Copy,
     L: for<'all> Lending<'all, Lend = &'all T>,
 {
-    fn len(&self) -> usize { self.lender.len() }
+    fn len(&self) -> usize {
+        self.lender.len()
+    }
 }
 impl<T, L> FusedIterator for Copied<L>
 where
@@ -50,5 +60,7 @@ impl<L> Default for Copied<L>
 where
     L: Default,
 {
-    fn default() -> Self { Self::new(L::default()) }
+    fn default() -> Self {
+        Self::new(L::default())
+    }
 }

--- a/src/adapters/cycle.rs
+++ b/src/adapters/cycle.rs
@@ -2,7 +2,7 @@ use core::{num::NonZeroUsize, ops::ControlFlow};
 
 use crate::{
     try_trait_v2::{FromResidual, Try},
-    FusedLender, Lender, Lending,
+    FusedLender, Lend, Lender, Lending,
 };
 
 #[derive(Clone, Debug)]
@@ -15,13 +15,15 @@ impl<L> Cycle<L>
 where
     L: Clone,
 {
-    pub(crate) fn new(lender: L) -> Cycle<L> { Cycle { orig: lender.clone(), lender } }
+    pub(crate) fn new(lender: L) -> Cycle<L> {
+        Cycle { orig: lender.clone(), lender }
+    }
 }
 impl<'lend, L> Lending<'lend> for Cycle<L>
 where
     L: Clone + Lender,
 {
-    type Lend = <L as Lending<'lend>>::Lend;
+    type Lend = Lend<'lend, L>;
 }
 impl<L> Lender for Cycle<L>
 where

--- a/src/adapters/enumerate.rs
+++ b/src/adapters/enumerate.rs
@@ -1,6 +1,6 @@
 use core::num::NonZeroUsize;
 
-use crate::{try_trait_v2::Try, DoubleEndedLender, ExactSizeLender, FusedLender, Lender, Lending};
+use crate::{try_trait_v2::Try, DoubleEndedLender, ExactSizeLender, FusedLender, Lend, Lender, Lending};
 #[derive(Clone, Debug)]
 #[must_use = "lenders are lazy and do nothing unless consumed"]
 pub struct Enumerate<L> {
@@ -8,13 +8,15 @@ pub struct Enumerate<L> {
     count: usize,
 }
 impl<L> Enumerate<L> {
-    pub(crate) fn new(lender: L) -> Enumerate<L> { Enumerate { lender, count: 0 } }
+    pub(crate) fn new(lender: L) -> Enumerate<L> {
+        Enumerate { lender, count: 0 }
+    }
 }
 impl<'lend, L> Lending<'lend> for Enumerate<L>
 where
     L: Lender,
 {
-    type Lend = (usize, <L as Lending<'lend>>::Lend);
+    type Lend = (usize, Lend<'lend, L>);
 }
 impl<L> Lender for Enumerate<L>
 where
@@ -29,7 +31,9 @@ where
         })
     }
     #[inline]
-    fn size_hint(&self) -> (usize, Option<usize>) { self.lender.size_hint() }
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.lender.size_hint()
+    }
     #[inline]
     fn nth(&mut self, n: usize) -> Option<<Self as Lending<'_>>::Lend> {
         let a = self.lender.nth(n)?;
@@ -38,7 +42,9 @@ where
         Some((i, a))
     }
     #[inline]
-    fn count(self) -> usize { self.lender.count() }
+    fn count(self) -> usize {
+        self.lender.count()
+    }
     #[inline]
     fn try_fold<B, F, R>(&mut self, init: B, mut f: F) -> R
     where
@@ -119,16 +125,24 @@ where
         })
     }
     #[inline]
-    fn advance_back_by(&mut self, n: usize) -> Result<(), NonZeroUsize> { self.lender.advance_back_by(n) }
+    fn advance_back_by(&mut self, n: usize) -> Result<(), NonZeroUsize> {
+        self.lender.advance_back_by(n)
+    }
 }
 impl<L> ExactSizeLender for Enumerate<L>
 where
     L: ExactSizeLender,
 {
-    fn len(&self) -> usize { self.lender.len() }
-    fn is_empty(&self) -> bool { self.lender.is_empty() }
+    fn len(&self) -> usize {
+        self.lender.len()
+    }
+    fn is_empty(&self) -> bool {
+        self.lender.is_empty()
+    }
 }
 impl<L> FusedLender for Enumerate<L> where L: FusedLender {}
 impl<L: Default> Default for Enumerate<L> {
-    fn default() -> Self { Enumerate::new(Default::default()) }
+    fn default() -> Self {
+        Enumerate::new(Default::default())
+    }
 }

--- a/src/adapters/filter_map.rs
+++ b/src/adapters/filter_map.rs
@@ -1,6 +1,6 @@
 use core::fmt;
 
-use crate::{higher_order::FnMutHKAOpt, DoubleEndedLender, FusedLender, Lender, Lending};
+use crate::{higher_order::FnMutHKAOpt, DoubleEndedLender, FusedLender, Lend, Lender, Lending};
 #[derive(Clone)]
 #[must_use = "lenders are lazy and do nothing unless consumed"]
 pub struct FilterMap<L, F> {
@@ -8,7 +8,9 @@ pub struct FilterMap<L, F> {
     f: F,
 }
 impl<L, F> FilterMap<L, F> {
-    pub(crate) fn new(lender: L, f: F) -> FilterMap<L, F> { FilterMap { lender, f } }
+    pub(crate) fn new(lender: L, f: F) -> FilterMap<L, F> {
+        FilterMap { lender, f }
+    }
 }
 impl<L: fmt::Debug, F> fmt::Debug for FilterMap<L, F> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -17,7 +19,7 @@ impl<L: fmt::Debug, F> fmt::Debug for FilterMap<L, F> {
 }
 impl<'lend, B, L, F> Lending<'lend> for FilterMap<L, F>
 where
-    F: FnMut(<L as Lending<'lend>>::Lend) -> Option<B>,
+    F: FnMut(Lend<'lend, L>) -> Option<B>,
     B: 'lend,
     L: Lender,
 {

--- a/src/adapters/flatten.rs
+++ b/src/adapters/flatten.rs
@@ -12,14 +12,18 @@ impl<'this, L: Lender> Flatten<'this, L>
 where
     for<'all> <L as Lending<'all>>::Lend: IntoLender,
 {
-    pub(crate) fn new(lender: L) -> Self { Self { inner: FlattenCompat::new(lender) } }
+    pub(crate) fn new(lender: L) -> Self {
+        Self { inner: FlattenCompat::new(lender) }
+    }
 }
 impl<'this, L: Lender + Clone> Clone for Flatten<'this, L>
 where
     for<'all> <L as Lending<'all>>::Lend: IntoLender,
     for<'all> <<L as Lending<'all>>::Lend as IntoLender>::Lender: Clone,
 {
-    fn clone(&self) -> Self { Flatten { inner: self.inner.clone() } }
+    fn clone(&self) -> Self {
+        Flatten { inner: self.inner.clone() }
+    }
 }
 impl<'this, L: Lender + fmt::Debug> fmt::Debug for Flatten<'this, L>
 where
@@ -34,16 +38,20 @@ impl<'lend, 'this, L: Lender> Lending<'lend> for Flatten<'this, L>
 where
     for<'all> <L as Lending<'all>>::Lend: IntoLender,
 {
-    type Lend = <<L as Lending<'this>>::Lend as Lending<'lend>>::Lend;
+    type Lend = <<<L as Lending<'this>>::Lend as IntoLender>::Lender as Lending<'lend>>::Lend;
 }
 impl<'this, L: Lender> Lender for Flatten<'this, L>
 where
     for<'all> <L as Lending<'all>>::Lend: IntoLender,
 {
     #[inline]
-    fn next(&mut self) -> Option<<Self as Lending<'_>>::Lend> { self.inner.next() }
+    fn next(&mut self) -> Option<<Self as Lending<'_>>::Lend> {
+        self.inner.next()
+    }
     #[inline]
-    fn size_hint(&self) -> (usize, Option<usize>) { self.inner.size_hint() }
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.inner.size_hint()
+    }
 }
 impl<'this, L: FusedLender> FusedLender for Flatten<'this, L> where for<'all> <L as Lending<'all>>::Lend: IntoLender {}
 
@@ -60,7 +68,9 @@ where
     Map<L, F>: Lender,
     for<'all> <Map<L, F> as Lending<'all>>::Lend: IntoLender,
 {
-    pub(crate) fn new(lender: L, f: F) -> Self { Self { inner: FlattenCompat::new(Map::new(lender, f)) } }
+    pub(crate) fn new(lender: L, f: F) -> Self {
+        Self { inner: FlattenCompat::new(Map::new(lender, f)) }
+    }
 }
 impl<'this, L: Lender + Clone, F: Clone> Clone for FlatMap<'this, L, F>
 where
@@ -68,7 +78,9 @@ where
     for<'all> <Map<L, F> as Lending<'all>>::Lend: IntoLender,
     for<'all> <<Map<L, F> as Lending<'all>>::Lend as IntoLender>::Lender: Clone,
 {
-    fn clone(&self) -> Self { FlatMap { inner: self.inner.clone() } }
+    fn clone(&self) -> Self {
+        FlatMap { inner: self.inner.clone() }
+    }
 }
 impl<'this, L: Lender + fmt::Debug, F> fmt::Debug for FlatMap<'this, L, F>
 where
@@ -85,7 +97,7 @@ where
     Map<L, F>: Lender,
     for<'all> <Map<L, F> as Lending<'all>>::Lend: IntoLender,
 {
-    type Lend = <<Map<L, F> as Lending<'this>>::Lend as Lending<'lend>>::Lend;
+    type Lend = <<<Map<L, F> as Lending<'this>>::Lend as IntoLender>::Lender as Lending<'lend>>::Lend;
 }
 impl<'this, L: Lender, F> Lender for FlatMap<'this, L, F>
 where
@@ -93,9 +105,13 @@ where
     for<'all> <Map<L, F> as Lending<'all>>::Lend: IntoLender,
 {
     #[inline]
-    fn next(&mut self) -> Option<<Self as Lending<'_>>::Lend> { self.inner.next() }
+    fn next(&mut self) -> Option<<Self as Lending<'_>>::Lend> {
+        self.inner.next()
+    }
     #[inline]
-    fn size_hint(&self) -> (usize, Option<usize>) { self.inner.size_hint() }
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.inner.size_hint()
+    }
 }
 impl<'this, L: FusedLender, F> FusedLender for FlatMap<'this, L, F>
 where
@@ -114,14 +130,18 @@ impl<'this, L: Lender> FlattenCompat<'this, L>
 where
     for<'all> <L as Lending<'all>>::Lend: IntoLender,
 {
-    pub(crate) fn new(lender: L) -> Self { Self { lender, inner: None } }
+    pub(crate) fn new(lender: L) -> Self {
+        Self { lender, inner: None }
+    }
 }
 impl<'this, L: Lender + Clone> Clone for FlattenCompat<'this, L>
 where
     for<'all> <L as Lending<'all>>::Lend: IntoLender,
     for<'all> <<L as Lending<'all>>::Lend as IntoLender>::Lender: Clone,
 {
-    fn clone(&self) -> Self { Self { lender: self.lender.clone(), inner: self.inner.clone() } }
+    fn clone(&self) -> Self {
+        Self { lender: self.lender.clone(), inner: self.inner.clone() }
+    }
 }
 impl<'this, L: Lender + fmt::Debug> fmt::Debug for FlattenCompat<'this, L>
 where
@@ -136,7 +156,7 @@ impl<'lend, 'this, L: Lender> Lending<'lend> for FlattenCompat<'this, L>
 where
     for<'all> <L as Lending<'all>>::Lend: IntoLender,
 {
-    type Lend = <<L as Lending<'this>>::Lend as Lending<'lend>>::Lend;
+    type Lend = <<<L as Lending<'this>>::Lend as IntoLender>::Lender as Lending<'lend>>::Lend;
 }
 impl<'this, L: Lender> Lender for FlattenCompat<'this, L>
 where

--- a/src/adapters/fuse.rs
+++ b/src/adapters/fuse.rs
@@ -2,7 +2,7 @@ use core::ops::ControlFlow;
 
 use crate::{
     try_trait_v2::{FromResidual, Try},
-    DoubleEndedLender, ExactSizeLender, FusedLender, Lender, Lending,
+    DoubleEndedLender, ExactSizeLender, FusedLender, Lend, Lender, Lending,
 };
 #[derive(Clone, Debug)]
 #[must_use = "lenders are lazy and do nothing unless consumed"]
@@ -11,14 +11,16 @@ pub struct Fuse<L> {
     flag: bool,
 }
 impl<L> Fuse<L> {
-    pub(crate) fn new(lender: L) -> Fuse<L> { Fuse { lender, flag: false } }
+    pub(crate) fn new(lender: L) -> Fuse<L> {
+        Fuse { lender, flag: false }
+    }
 }
 impl<L> FusedLender for Fuse<L> where L: Lender {}
 impl<'lend, L> Lending<'lend> for Fuse<L>
 where
     L: Lender,
 {
-    type Lend = <L as Lending<'lend>>::Lend;
+    type Lend = Lend<'lend, L>;
 }
 impl<L> Lender for Fuse<L>
 where
@@ -205,5 +207,7 @@ where
     }
 }
 impl<L: Default> Default for Fuse<L> {
-    fn default() -> Self { Self::new(L::default()) }
+    fn default() -> Self {
+        Self::new(L::default())
+    }
 }

--- a/src/adapters/intersperse.rs
+++ b/src/adapters/intersperse.rs
@@ -1,6 +1,6 @@
 use core::fmt;
 
-use crate::{Lender, Lending, Peekable};
+use crate::{Lend, Lender, Lending, Peekable};
 
 #[derive(Clone)]
 #[must_use = "lenders are lazy and do nothing unless consumed"]
@@ -40,7 +40,7 @@ where
     for<'all> <L as Lending<'all>>::Lend: Clone,
     L: Lender,
 {
-    type Lend = <L as Lending<'lend>>::Lend;
+    type Lend = Lend<'lend, L>;
 }
 impl<'this, L> Lender for Intersperse<'this, L>
 where
@@ -78,7 +78,9 @@ where
             acc
         })
     }
-    fn size_hint(&self) -> (usize, Option<usize>) { intersperse_size_hint(&self.lender, self.needs_sep) }
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        intersperse_size_hint(&self.lender, self.needs_sep)
+    }
 }
 
 #[derive(Clone)]
@@ -118,7 +120,7 @@ where
     L: Lender,
     G: FnMut() -> <L as Lending<'this>>::Lend,
 {
-    type Lend = <L as Lending<'lend>>::Lend;
+    type Lend = Lend<'lend, L>;
 }
 impl<'this, L, G> Lender for IntersperseWith<'this, L, G>
 where
@@ -156,7 +158,9 @@ where
             acc
         })
     }
-    fn size_hint(&self) -> (usize, Option<usize>) { intersperse_size_hint(&self.lender, self.needs_sep) }
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        intersperse_size_hint(&self.lender, self.needs_sep)
+    }
 }
 
 fn intersperse_size_hint<L>(lender: &L, needs_sep: bool) -> (usize, Option<usize>)

--- a/src/adapters/iter.rs
+++ b/src/adapters/iter.rs
@@ -30,7 +30,9 @@ pub struct Iter<'this, L: 'this> {
     _marker: PhantomData<&'this ()>,
 }
 impl<'this, L: 'this> Iter<'this, L> {
-    pub(crate) fn new(lender: L) -> Iter<'this, L> { Iter { lender, _marker: PhantomData } }
+    pub(crate) fn new(lender: L) -> Iter<'this, L> {
+        Iter { lender, _marker: PhantomData }
+    }
 }
 impl<'this, L: 'this> Iterator for Iter<'this, L>
 where
@@ -46,7 +48,9 @@ where
         }
     }
     #[inline]
-    fn size_hint(&self) -> (usize, Option<usize>) { self.lender.size_hint() }
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.lender.size_hint()
+    }
 }
 impl<'this, L: 'this> DoubleEndedIterator for Iter<'this, L>
 where
@@ -69,7 +73,9 @@ where
     for<'all> <L as Lending<'all>>::Lend: 'this,
 {
     #[inline]
-    fn len(&self) -> usize { self.lender.len() }
+    fn len(&self) -> usize {
+        self.lender.len()
+    }
 }
 impl<'this, L: 'this> FusedIterator for Iter<'this, L>
 where

--- a/src/adapters/map_while.rs
+++ b/src/adapters/map_while.rs
@@ -1,6 +1,6 @@
 use core::fmt;
 
-use crate::{higher_order::FnMutHKAOpt, Lender, Lending};
+use crate::{higher_order::FnMutHKAOpt, Lend, Lender, Lending};
 #[derive(Clone)]
 #[must_use = "lenders are lazy and do nothing unless consumed"]
 pub struct MapWhile<L, P> {
@@ -8,7 +8,9 @@ pub struct MapWhile<L, P> {
     predicate: P,
 }
 impl<L, P> MapWhile<L, P> {
-    pub(crate) fn new(lender: L, predicate: P) -> MapWhile<L, P> { MapWhile { lender, predicate } }
+    pub(crate) fn new(lender: L, predicate: P) -> MapWhile<L, P> {
+        MapWhile { lender, predicate }
+    }
 }
 impl<L: fmt::Debug, P> fmt::Debug for MapWhile<L, P> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -17,7 +19,7 @@ impl<L: fmt::Debug, P> fmt::Debug for MapWhile<L, P> {
 }
 impl<'lend, B, L, P> Lending<'lend> for MapWhile<L, P>
 where
-    P: FnMut(<L as Lending<'lend>>::Lend) -> Option<B>,
+    P: FnMut(Lend<'lend, L>) -> Option<B>,
     L: Lender,
     B: 'lend,
 {
@@ -29,7 +31,9 @@ where
     L: Lender,
 {
     #[inline]
-    fn next(&mut self) -> Option<<Self as Lending<'_>>::Lend> { (self.predicate)(self.lender.next()?) }
+    fn next(&mut self) -> Option<<Self as Lending<'_>>::Lend> {
+        (self.predicate)(self.lender.next()?)
+    }
     #[inline]
     fn size_hint(&self) -> (usize, Option<usize>) {
         let (_, upper) = self.lender.size_hint();

--- a/src/adapters/mod.rs
+++ b/src/adapters/mod.rs
@@ -62,7 +62,7 @@ pub use self::{
 use crate::{
     empty,
     try_trait_v2::{ChangeOutputType, FromResidual, Residual, Try},
-    Empty, ExtendLender, IntoLender, Lender, Lending, TupleLend,
+    Empty, ExtendLender, IntoLender, Lend, Lender, Lending, TupleLend,
 };
 
 // pub use zip::{TrustedRandomAccess, TrustedRandomAccessNoCoerce};
@@ -81,7 +81,7 @@ impl<'lend, 'this, L: Lender> Lending<'lend> for TryShunt<'this, L>
 where
     for<'all> <L as Lending<'all>>::Lend: Try,
 {
-    type Lend = <<L as Lending<'lend>>::Lend as Try>::Output;
+    type Lend = <Lend<'lend, L> as Try>::Output;
 }
 impl<'this, L: Lender> Lender for TryShunt<'this, L>
 where
@@ -135,13 +135,13 @@ impl<'lend, L: Lender> Lending<'lend> for FirstShunt<L>
 where
     for<'all> <L as Lending<'all>>::Lend: TupleLend<'all>,
 {
-    type Lend = <<L as Lending<'lend>>::Lend as TupleLend<'lend>>::First;
+    type Lend = <Lend<'lend, L> as TupleLend<'lend>>::First;
 }
 impl<'lend, L: Lender> Lending<'lend> for SecondShunt<L>
 where
     for<'all> <L as Lending<'all>>::Lend: TupleLend<'all>,
 {
-    type Lend = <<L as Lending<'lend>>::Lend as TupleLend<'lend>>::Second;
+    type Lend = <Lend<'lend, L> as TupleLend<'lend>>::Second;
 }
 impl<L: Lender> IntoLender for FirstShunt<L>
 where

--- a/src/adapters/mod.rs
+++ b/src/adapters/mod.rs
@@ -148,14 +148,18 @@ where
     for<'all> <L as Lending<'all>>::Lend: TupleLend<'all>,
 {
     type Lender = Empty<Self>;
-    fn into_lender(self) -> <Self as IntoLender>::Lender { empty() }
+    fn into_lender(self) -> <Self as IntoLender>::Lender {
+        empty()
+    }
 }
 impl<L: Lender> IntoLender for SecondShunt<L>
 where
     for<'all> <L as Lending<'all>>::Lend: TupleLend<'all>,
 {
     type Lender = Empty<Self>;
-    fn into_lender(self) -> <Self as IntoLender>::Lender { empty() }
+    fn into_lender(self) -> <Self as IntoLender>::Lender {
+        empty()
+    }
 }
 
 pub(crate) fn unzip<L, ExtA, ExtB>(mut lender: L) -> (ExtA, ExtB)

--- a/src/adapters/mutate.rs
+++ b/src/adapters/mutate.rs
@@ -1,6 +1,6 @@
 use core::fmt;
 
-use crate::{try_trait_v2::Try, DoubleEndedLender, ExactSizeLender, FusedLender, Lender, Lending};
+use crate::{try_trait_v2::Try, DoubleEndedLender, ExactSizeLender, FusedLender, Lend, Lender, Lending};
 #[derive(Clone)]
 #[must_use = "lenders are lazy and do nothing unless consumed"]
 pub struct Mutate<L, F> {
@@ -8,7 +8,9 @@ pub struct Mutate<L, F> {
     f: F,
 }
 impl<L, F> Mutate<L, F> {
-    pub(crate) fn new(lender: L, f: F) -> Mutate<L, F> { Mutate { lender, f } }
+    pub(crate) fn new(lender: L, f: F) -> Mutate<L, F> {
+        Mutate { lender, f }
+    }
 }
 impl<L: fmt::Debug, F> fmt::Debug for Mutate<L, F> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -18,9 +20,9 @@ impl<L: fmt::Debug, F> fmt::Debug for Mutate<L, F> {
 impl<'lend, L, F> Lending<'lend> for Mutate<L, F>
 where
     L: Lender,
-    F: FnMut(&mut <L as Lending<'lend>>::Lend),
+    F: FnMut(&mut Lend<'lend, L>),
 {
-    type Lend = <L as Lending<'lend>>::Lend;
+    type Lend = Lend<'lend, L>;
 }
 impl<L, F> Lender for Mutate<L, F>
 where
@@ -36,7 +38,9 @@ where
         next
     }
     #[inline]
-    fn size_hint(&self) -> (usize, Option<usize>) { self.lender.size_hint() }
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.lender.size_hint()
+    }
     #[inline]
     fn try_fold<B, Fold, R>(&mut self, init: B, mut fold: Fold) -> R
     where
@@ -105,8 +109,12 @@ where
     F: FnMut(&mut <L as Lending<'_>>::Lend),
 {
     #[inline]
-    fn len(&self) -> usize { self.lender.len() }
+    fn len(&self) -> usize {
+        self.lender.len()
+    }
     #[inline]
-    fn is_empty(&self) -> bool { self.lender.is_empty() }
+    fn is_empty(&self) -> bool {
+        self.lender.is_empty()
+    }
 }
 impl<L: FusedLender, F> FusedLender for Mutate<L, F> where F: FnMut(&mut <L as Lending<'_>>::Lend) {}

--- a/src/adapters/owned.rs
+++ b/src/adapters/owned.rs
@@ -8,7 +8,9 @@ pub struct Owned<L> {
     lender: L,
 }
 impl<L> Owned<L> {
-    pub(crate) fn new(lender: L) -> Self { Self { lender } }
+    pub(crate) fn new(lender: L) -> Self {
+        Self { lender }
+    }
 }
 impl<T, L> Iterator for Owned<L>
 where
@@ -17,9 +19,13 @@ where
 {
     type Item = T;
     #[inline]
-    fn next(&mut self) -> Option<Self::Item> { self.lender.next().map(|ref x| x.to_owned()) }
+    fn next(&mut self) -> Option<Self::Item> {
+        self.lender.next().map(|ref x| x.to_owned())
+    }
     #[inline]
-    fn size_hint(&self) -> (usize, Option<usize>) { self.lender.size_hint() }
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.lender.size_hint()
+    }
 }
 impl<T, L> DoubleEndedIterator for Owned<L>
 where
@@ -27,14 +33,18 @@ where
     for<'all> <L as Lending<'all>>::Lend: ToOwned<Owned = T>,
 {
     #[inline]
-    fn next_back(&mut self) -> Option<Self::Item> { self.lender.next_back().map(|ref x| x.to_owned()) }
+    fn next_back(&mut self) -> Option<Self::Item> {
+        self.lender.next_back().map(|ref x| x.to_owned())
+    }
 }
 impl<T, L> ExactSizeIterator for Owned<L>
 where
     L: ExactSizeLender,
     for<'all> <L as Lending<'all>>::Lend: ToOwned<Owned = T>,
 {
-    fn len(&self) -> usize { self.lender.len() }
+    fn len(&self) -> usize {
+        self.lender.len()
+    }
 }
 impl<T, L> FusedIterator for Owned<L>
 where
@@ -46,5 +56,7 @@ impl<L> Default for Owned<L>
 where
     L: Default,
 {
-    fn default() -> Self { Self::new(L::default()) }
+    fn default() -> Self {
+        Self::new(L::default())
+    }
 }

--- a/src/adapters/peekable.rs
+++ b/src/adapters/peekable.rs
@@ -2,7 +2,7 @@ use core::{fmt, ops::ControlFlow};
 
 use crate::{
     try_trait_v2::{FromResidual, Try},
-    DoubleEndedLender, ExactSizeLender, FusedLender, Lender, Lending,
+    DoubleEndedLender, ExactSizeLender, FusedLender, Lend, Lender, Lending,
 };
 
 #[must_use = "lenders are lazy and do nothing unless consumed"]
@@ -17,7 +17,9 @@ impl<'this, L> Peekable<'this, L>
 where
     L: Lender,
 {
-    pub(crate) fn new(lender: L) -> Peekable<'this, L> { Peekable { lender, peeked: None } }
+    pub(crate) fn new(lender: L) -> Peekable<'this, L> {
+        Peekable { lender, peeked: None }
+    }
     pub fn peek(&mut self) -> Option<&'_ <L as Lending<'this>>::Lend> {
         let lender = &mut self.lender;
         self.peeked
@@ -71,7 +73,9 @@ impl<'this, L> Clone for Peekable<'this, L>
 where
     L: Lender + Clone,
 {
-    fn clone(&self) -> Self { Peekable { lender: self.lender.clone(), peeked: None } }
+    fn clone(&self) -> Self {
+        Peekable { lender: self.lender.clone(), peeked: None }
+    }
 }
 impl<'this, L: fmt::Debug> fmt::Debug for Peekable<'this, L>
 where
@@ -86,7 +90,7 @@ impl<'lend, 'this, L> Lending<'lend> for Peekable<'this, L>
 where
     L: Lender,
 {
-    type Lend = <L as Lending<'lend>>::Lend;
+    type Lend = Lend<'lend, L>;
 }
 impl<'this, L> Lender for Peekable<'this, L>
 where

--- a/src/adapters/rev.rs
+++ b/src/adapters/rev.rs
@@ -1,30 +1,40 @@
-use crate::{try_trait_v2::Try, DoubleEndedLender, ExactSizeLender, FusedLender, Lender, Lending};
+use crate::{try_trait_v2::Try, DoubleEndedLender, ExactSizeLender, FusedLender, Lend, Lender, Lending};
 #[derive(Clone, Debug)]
 #[must_use = "lenders are lazy and do nothing unless consumed"]
 pub struct Rev<L> {
     lender: L,
 }
 impl<L> Rev<L> {
-    pub(crate) fn new(lender: L) -> Rev<L> { Rev { lender } }
+    pub(crate) fn new(lender: L) -> Rev<L> {
+        Rev { lender }
+    }
 }
 impl<'lend, L> Lending<'lend> for Rev<L>
 where
     L: Lender,
 {
-    type Lend = <L as Lending<'lend>>::Lend;
+    type Lend = Lend<'lend, L>;
 }
 impl<L> Lender for Rev<L>
 where
     L: DoubleEndedLender,
 {
     #[inline]
-    fn next(&mut self) -> Option<<Self as Lending<'_>>::Lend> { self.lender.next_back() }
+    fn next(&mut self) -> Option<<Self as Lending<'_>>::Lend> {
+        self.lender.next_back()
+    }
     #[inline]
-    fn size_hint(&self) -> (usize, Option<usize>) { self.lender.size_hint() }
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.lender.size_hint()
+    }
     #[inline]
-    fn advance_by(&mut self, n: usize) -> Result<(), core::num::NonZeroUsize> { self.lender.advance_back_by(n) }
+    fn advance_by(&mut self, n: usize) -> Result<(), core::num::NonZeroUsize> {
+        self.lender.advance_back_by(n)
+    }
     #[inline]
-    fn nth(&mut self, n: usize) -> Option<<Self as Lending<'_>>::Lend> { self.lender.nth_back(n) }
+    fn nth(&mut self, n: usize) -> Option<<Self as Lending<'_>>::Lend> {
+        self.lender.nth_back(n)
+    }
     fn try_fold<B, F, R>(&mut self, init: B, f: F) -> R
     where
         Self: Sized,
@@ -54,11 +64,17 @@ where
     L: DoubleEndedLender,
 {
     #[inline]
-    fn next_back(&mut self) -> Option<<Self as Lending<'_>>::Lend> { self.lender.next() }
+    fn next_back(&mut self) -> Option<<Self as Lending<'_>>::Lend> {
+        self.lender.next()
+    }
     #[inline]
-    fn advance_back_by(&mut self, n: usize) -> Result<(), core::num::NonZeroUsize> { self.lender.advance_by(n) }
+    fn advance_back_by(&mut self, n: usize) -> Result<(), core::num::NonZeroUsize> {
+        self.lender.advance_by(n)
+    }
     #[inline]
-    fn nth_back(&mut self, n: usize) -> Option<<Self as Lending<'_>>::Lend> { self.lender.nth(n) }
+    fn nth_back(&mut self, n: usize) -> Option<<Self as Lending<'_>>::Lend> {
+        self.lender.nth(n)
+    }
     fn try_rfold<B, F, R>(&mut self, init: B, f: F) -> R
     where
         Self: Sized,
@@ -87,12 +103,16 @@ where
     L: DoubleEndedLender + ExactSizeLender,
 {
     #[inline]
-    fn len(&self) -> usize { self.lender.len() }
+    fn len(&self) -> usize {
+        self.lender.len()
+    }
 }
 impl<L> FusedLender for Rev<L> where L: DoubleEndedLender + FusedLender {}
 impl<L> Default for Rev<L>
 where
     L: Default,
 {
-    fn default() -> Self { Rev::new(L::default()) }
+    fn default() -> Self {
+        Rev::new(L::default())
+    }
 }

--- a/src/adapters/scan.rs
+++ b/src/adapters/scan.rs
@@ -1,6 +1,6 @@
 use core::fmt;
 
-use crate::{higher_order::FnMutHKAOpt, Lender, Lending};
+use crate::{higher_order::FnMutHKAOpt, Lend, Lender, Lending};
 #[derive(Clone)]
 #[must_use = "lenders are lazy and do nothing unless consumed"]
 pub struct Scan<L, St, F> {
@@ -9,7 +9,9 @@ pub struct Scan<L, St, F> {
     state: St,
 }
 impl<L, St, F> Scan<L, St, F> {
-    pub(crate) fn new(lender: L, state: St, f: F) -> Scan<L, St, F> { Scan { lender, state, f } }
+    pub(crate) fn new(lender: L, state: St, f: F) -> Scan<L, St, F> {
+        Scan { lender, state, f }
+    }
 }
 impl<L: fmt::Debug, St: fmt::Debug, F> fmt::Debug for Scan<L, St, F> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -18,7 +20,7 @@ impl<L: fmt::Debug, St: fmt::Debug, F> fmt::Debug for Scan<L, St, F> {
 }
 impl<'lend, B, L, St, F> Lending<'lend> for Scan<L, St, F>
 where
-    F: FnMut((&'lend mut St, <L as Lending<'lend>>::Lend)) -> Option<B>,
+    F: FnMut((&'lend mut St, Lend<'lend, L>)) -> Option<B>,
     L: Lender,
     B: 'lend,
 {
@@ -30,7 +32,9 @@ where
     L: Lender,
 {
     #[inline]
-    fn next(&mut self) -> Option<<Self as Lending<'_>>::Lend> { (self.f)((&mut self.state, self.lender.next()?)) }
+    fn next(&mut self) -> Option<<Self as Lending<'_>>::Lend> {
+        (self.f)((&mut self.state, self.lender.next()?))
+    }
     #[inline]
     fn size_hint(&self) -> (usize, Option<usize>) {
         let (_, upper) = self.lender.size_hint();

--- a/src/adapters/skip.rs
+++ b/src/adapters/skip.rs
@@ -1,6 +1,6 @@
 use core::{num::NonZeroUsize, ops::ControlFlow};
 
-use crate::{try_trait_v2::Try, DoubleEndedLender, ExactSizeLender, FusedLender, Lender, Lending};
+use crate::{try_trait_v2::Try, DoubleEndedLender, ExactSizeLender, FusedLender, Lend, Lender, Lending};
 #[derive(Clone, Debug)]
 #[must_use = "lenders are lazy and do nothing unless consumed"]
 pub struct Skip<L> {
@@ -8,13 +8,15 @@ pub struct Skip<L> {
     n: usize,
 }
 impl<L> Skip<L> {
-    pub(crate) fn new(lender: L, n: usize) -> Skip<L> { Skip { lender, n } }
+    pub(crate) fn new(lender: L, n: usize) -> Skip<L> {
+        Skip { lender, n }
+    }
 }
 impl<'lend, L> Lending<'lend> for Skip<L>
 where
     L: Lender,
 {
-    type Lend = <L as Lending<'lend>>::Lend;
+    type Lend = Lend<'lend, L>;
 }
 impl<L> Lender for Skip<L>
 where

--- a/src/adapters/skip_while.rs
+++ b/src/adapters/skip_while.rs
@@ -1,6 +1,6 @@
 use core::{fmt, ops::ControlFlow};
 
-use crate::{try_trait_v2::Try, FusedLender, Lender, Lending};
+use crate::{try_trait_v2::Try, FusedLender, Lend, Lender, Lending};
 #[derive(Clone)]
 #[must_use = "lenders are lazy and do nothing unless consumed"]
 pub struct SkipWhile<L, P> {
@@ -9,7 +9,9 @@ pub struct SkipWhile<L, P> {
     predicate: P,
 }
 impl<L, P> SkipWhile<L, P> {
-    pub(crate) fn new(lender: L, predicate: P) -> SkipWhile<L, P> { SkipWhile { lender, flag: false, predicate } }
+    pub(crate) fn new(lender: L, predicate: P) -> SkipWhile<L, P> {
+        SkipWhile { lender, flag: false, predicate }
+    }
 }
 impl<L: fmt::Debug, P> fmt::Debug for SkipWhile<L, P> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -18,10 +20,10 @@ impl<L: fmt::Debug, P> fmt::Debug for SkipWhile<L, P> {
 }
 impl<'lend, L, P> Lending<'lend> for SkipWhile<L, P>
 where
-    P: FnMut(&<L as Lending<'lend>>::Lend) -> bool,
+    P: FnMut(&Lend<'lend, L>) -> bool,
     L: Lender,
 {
-    type Lend = <L as Lending<'lend>>::Lend;
+    type Lend = Lend<'lend, L>;
 }
 impl<L, P> Lender for SkipWhile<L, P>
 where

--- a/src/adapters/step_by.rs
+++ b/src/adapters/step_by.rs
@@ -1,6 +1,6 @@
 use core::ops::ControlFlow;
 
-use crate::{try_trait_v2::Try, DoubleEndedLender, ExactSizeLender, Lender, Lending};
+use crate::{try_trait_v2::Try, DoubleEndedLender, ExactSizeLender, Lend, Lender, Lending};
 #[derive(Clone, Debug)]
 #[must_use = "lenders are lazy and do nothing unless consumed"]
 pub struct StepBy<L> {
@@ -18,7 +18,7 @@ impl<'lend, L> Lending<'lend> for StepBy<L>
 where
     L: Lender,
 {
-    type Lend = <L as Lending<'lend>>::Lend;
+    type Lend = Lend<'lend, L>;
 }
 impl<L> Lender for StepBy<L>
 where
@@ -147,7 +147,9 @@ where
     L: DoubleEndedLender + ExactSizeLender,
 {
     #[inline]
-    fn next_back(&mut self) -> Option<<Self as Lending<'_>>::Lend> { self.lender.nth_back(self.next_back_index()) }
+    fn next_back(&mut self) -> Option<<Self as Lending<'_>>::Lend> {
+        self.lender.nth_back(self.next_back_index())
+    }
 
     #[inline]
     fn nth_back(&mut self, n: usize) -> Option<<Self as Lending<'_>>::Lend> {

--- a/src/adapters/take.rs
+++ b/src/adapters/take.rs
@@ -1,6 +1,6 @@
 use core::num::NonZeroUsize;
 
-use crate::{try_trait_v2::Try, DoubleEndedLender, ExactSizeLender, FusedLender, Lender, Lending};
+use crate::{try_trait_v2::Try, DoubleEndedLender, ExactSizeLender, FusedLender, Lend, Lender, Lending};
 #[derive(Clone, Debug)]
 #[must_use = "lenders are lazy and do nothing unless consumed"]
 pub struct Take<L> {
@@ -8,13 +8,15 @@ pub struct Take<L> {
     n: usize,
 }
 impl<L> Take<L> {
-    pub(crate) fn new(lender: L, n: usize) -> Take<L> { Take { lender, n } }
+    pub(crate) fn new(lender: L, n: usize) -> Take<L> {
+        Take { lender, n }
+    }
 }
 impl<'lend, L> Lending<'lend> for Take<L>
 where
     L: Lender,
 {
-    type Lend = <L as Lending<'lend>>::Lend;
+    type Lend = Lend<'lend, L>;
 }
 impl<L> Lender for Take<L>
 where

--- a/src/adapters/take_while.rs
+++ b/src/adapters/take_while.rs
@@ -1,6 +1,6 @@
 use core::fmt;
 
-use crate::{FusedLender, Lender, Lending};
+use crate::{FusedLender, Lend, Lender, Lending};
 #[derive(Clone)]
 #[must_use = "lenders are lazy and do nothing unless consumed"]
 pub struct TakeWhile<L, P> {
@@ -9,7 +9,9 @@ pub struct TakeWhile<L, P> {
     predicate: P,
 }
 impl<L, P> TakeWhile<L, P> {
-    pub(crate) fn new(lender: L, predicate: P) -> TakeWhile<L, P> { TakeWhile { lender, flag: false, predicate } }
+    pub(crate) fn new(lender: L, predicate: P) -> TakeWhile<L, P> {
+        TakeWhile { lender, flag: false, predicate }
+    }
 }
 impl<L: fmt::Debug, P> fmt::Debug for TakeWhile<L, P> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -18,10 +20,10 @@ impl<L: fmt::Debug, P> fmt::Debug for TakeWhile<L, P> {
 }
 impl<'lend, L, P> Lending<'lend> for TakeWhile<L, P>
 where
-    P: FnMut(&<L as Lending<'lend>>::Lend) -> bool,
+    P: FnMut(&Lend<'lend, L>) -> bool,
     L: Lender,
 {
-    type Lend = <L as Lending<'lend>>::Lend;
+    type Lend = Lend<'lend, L>;
 }
 impl<L, P> Lender for TakeWhile<L, P>
 where

--- a/src/adapters/zip.rs
+++ b/src/adapters/zip.rs
@@ -15,7 +15,9 @@ pub struct Zip<A, B> {
     b: B,
 }
 impl<A, B> Zip<A, B> {
-    pub(crate) fn new(a: A, b: B) -> Self { Self { a, b } }
+    pub(crate) fn new(a: A, b: B) -> Self {
+        Self { a, b }
+    }
 }
 impl<'lend, A, B> Lending<'lend> for Zip<A, B>
 where
@@ -30,7 +32,9 @@ where
     B: Lender,
 {
     #[inline]
-    fn next(&mut self) -> Option<<Self as Lending<'_>>::Lend> { Some((self.a.next()?, self.b.next()?)) }
+    fn next(&mut self) -> Option<<Self as Lending<'_>>::Lend> {
+        Some((self.a.next()?, self.b.next()?))
+    }
     #[inline]
     fn size_hint(&self) -> (usize, Option<usize>) {
         let (a_lower, a_upper) = self.a.size_hint();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -199,7 +199,7 @@ pub mod try_trait_v2;
 
 pub mod prelude {
     pub use crate::{
-        hrc, hrc_mut, hrc_once, lend, DoubleEndedLender, ExactSizeLender, ExtendLender, FromLender, IntoLender, Lender,
-        Lending,
+        hrc, hrc_mut, hrc_once, lend, DoubleEndedLender, ExactSizeLender, ExtendLender, FromLender, IntoLender, Lend,
+        Lender, Lending,
     };
 }

--- a/src/sources/empty.rs
+++ b/src/sources/empty.rs
@@ -1,6 +1,6 @@
 use core::{fmt, marker};
 
-use crate::{DoubleEndedLender, ExactSizeLender, FusedLender, Lender, Lending};
+use crate::{DoubleEndedLender, ExactSizeLender, FusedLender, Lend, Lender, Lending};
 
 /// Creates a lender that yields nothing.
 ///
@@ -13,7 +13,9 @@ use crate::{DoubleEndedLender, ExactSizeLender, FusedLender, Lender, Lending};
 /// let x: Option<&'_ mut u32> = e.next();
 /// assert_eq!(x, None);
 /// ```
-pub const fn empty<L: ?Sized + for<'all> Lending<'all>>() -> Empty<L> { Empty(marker::PhantomData) }
+pub const fn empty<L: ?Sized + for<'all> Lending<'all>>() -> Empty<L> {
+    Empty(marker::PhantomData)
+}
 
 /// A lender that yields nothing.
 ///
@@ -24,43 +26,57 @@ pub const fn empty<L: ?Sized + for<'all> Lending<'all>>() -> Empty<L> { Empty(ma
 pub struct Empty<L: ?Sized>(marker::PhantomData<L>);
 
 impl<L: ?Sized> fmt::Debug for Empty<L> {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result { f.debug_struct("Empty").finish() }
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Empty").finish()
+    }
 }
 
 impl<'lend, L> Lending<'lend> for Empty<L>
 where
     L: ?Sized + for<'all> Lending<'all>,
 {
-    type Lend = <L as Lending<'lend>>::Lend;
+    type Lend = Lend<'lend, L>;
 }
 impl<L> Lender for Empty<L>
 where
     L: ?Sized + for<'all> Lending<'all>,
 {
-    fn next(&mut self) -> Option<<Self as Lending<'_>>::Lend> { None }
-    fn size_hint(&self) -> (usize, Option<usize>) { (0, Some(0)) }
+    fn next(&mut self) -> Option<<Self as Lending<'_>>::Lend> {
+        None
+    }
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        (0, Some(0))
+    }
 }
 
 impl<L> DoubleEndedLender for Empty<L>
 where
     L: ?Sized + for<'all> Lending<'all>,
 {
-    fn next_back(&mut self) -> Option<<Self as Lending<'_>>::Lend> { None }
+    fn next_back(&mut self) -> Option<<Self as Lending<'_>>::Lend> {
+        None
+    }
 }
 
 impl<L> ExactSizeLender for Empty<L>
 where
     L: ?Sized + for<'all> Lending<'all>,
 {
-    fn len(&self) -> usize { 0 }
+    fn len(&self) -> usize {
+        0
+    }
 }
 
 impl<L> FusedLender for Empty<L> where L: ?Sized + for<'all> Lending<'all> {}
 
 impl<L: ?Sized> Clone for Empty<L> {
-    fn clone(&self) -> Empty<L> { Empty(marker::PhantomData) }
+    fn clone(&self) -> Empty<L> {
+        Empty(marker::PhantomData)
+    }
 }
 
 impl<L: ?Sized> Default for Empty<L> {
-    fn default() -> Empty<L> { Empty(marker::PhantomData) }
+    fn default() -> Empty<L> {
+        Empty(marker::PhantomData)
+    }
 }

--- a/src/sources/from_fn.rs
+++ b/src/sources/from_fn.rs
@@ -51,5 +51,7 @@ where
     F: for<'all> FnMutHKAOpt<'all, &'all mut St>,
 {
     #[inline]
-    fn next(&mut self) -> Option<<Self as Lending<'_>>::Lend> { (self.f)(&mut self.state) }
+    fn next(&mut self) -> Option<<Self as Lending<'_>>::Lend> {
+        (self.f)(&mut self.state)
+    }
 }

--- a/src/sources/from_iter.rs
+++ b/src/sources/from_iter.rs
@@ -16,7 +16,9 @@ use crate::{prelude::*, FusedLender};
 /// let x: u8 = *item + *item2; // == 3
 /// ```
 #[inline]
-pub fn from_iter<I: Iterator>(iter: I) -> FromIter<I> { FromIter { iter } }
+pub fn from_iter<I: Iterator>(iter: I) -> FromIter<I> {
+    FromIter { iter }
+}
 
 /// A lender that yields elements from an iterator.
 ///
@@ -35,17 +37,25 @@ impl<'lend, I: Iterator> Lending<'lend> for FromIter<I> {
 
 impl<I: Iterator> Lender for FromIter<I> {
     #[inline]
-    fn next(&mut self) -> Option<<Self as Lending<'_>>::Lend> { self.iter.next() }
+    fn next(&mut self) -> Option<<Self as Lending<'_>>::Lend> {
+        self.iter.next()
+    }
     #[inline]
-    fn size_hint(&self) -> (usize, Option<usize>) { self.iter.size_hint() }
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.iter.size_hint()
+    }
 }
 
 impl<I: DoubleEndedIterator> DoubleEndedLender for FromIter<I> {
-    fn next_back(&mut self) -> Option<<Self as Lending<'_>>::Lend> { self.iter.next_back() }
+    fn next_back(&mut self) -> Option<<Self as Lending<'_>>::Lend> {
+        self.iter.next_back()
+    }
 }
 
 impl<I: ExactSizeIterator> ExactSizeLender for FromIter<I> {
-    fn len(&self) -> usize { self.iter.len() }
+    fn len(&self) -> usize {
+        self.iter.len()
+    }
 }
 
 impl<I: FusedIterator> FusedLender for FromIter<I> {}
@@ -95,7 +105,7 @@ where
     L: ?Sized + for<'all> Lending<'all> + 'a,
     I: Iterator<Item = <L as Lending<'a>>::Lend>,
 {
-    type Lend = <L as Lending<'lend>>::Lend;
+    type Lend = Lend<'lend, L>;
 }
 
 impl<'a, L, I> Lender for LendIter<'a, L, I>
@@ -113,7 +123,9 @@ where
         }
     }
     #[inline]
-    fn size_hint(&self) -> (usize, Option<usize>) { self.iter.size_hint() }
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.iter.size_hint()
+    }
 }
 
 impl<'a, L, I> DoubleEndedLender for LendIter<'a, L, I>
@@ -136,7 +148,9 @@ where
     L: ?Sized + for<'all> Lending<'all> + 'a,
     I: ExactSizeIterator<Item = <L as Lending<'a>>::Lend>,
 {
-    fn len(&self) -> usize { self.iter.len() }
+    fn len(&self) -> usize {
+        self.iter.len()
+    }
 }
 
 impl<'a, L, I> FusedLender for LendIter<'a, L, I>

--- a/src/sources/once.rs
+++ b/src/sources/once.rs
@@ -1,6 +1,6 @@
 use core::fmt;
 
-use crate::{DoubleEndedLender, ExactSizeLender, FusedLender, Lender, Lending};
+use crate::{DoubleEndedLender, ExactSizeLender, FusedLender, Lend, Lender, Lending};
 
 /// Creates a lender that yields an element exactly once.
 ///
@@ -35,20 +35,24 @@ where
     L: ?Sized + for<'all> Lending<'all>,
     <L as Lending<'a>>::Lend: Clone,
 {
-    fn clone(&self) -> Self { Once { inner: self.inner.clone() } }
+    fn clone(&self) -> Self {
+        Once { inner: self.inner.clone() }
+    }
 }
 impl<'a, L> fmt::Debug for Once<'a, L>
 where
     L: ?Sized + for<'all> Lending<'all>,
     <L as Lending<'a>>::Lend: fmt::Debug,
 {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result { f.debug_struct("Once").field("inner", &self.inner).finish() }
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Once").field("inner", &self.inner).finish()
+    }
 }
 impl<'a, 'lend, L> Lending<'lend> for Once<'a, L>
 where
     L: ?Sized + for<'all> Lending<'all>,
 {
-    type Lend = <L as Lending<'lend>>::Lend;
+    type Lend = Lend<'lend, L>;
 }
 
 impl<'a, L> Lender for Once<'a, L>
@@ -75,7 +79,9 @@ where
     L: ?Sized + for<'all> Lending<'all>,
 {
     #[inline]
-    fn next_back(&mut self) -> Option<<Self as Lending<'_>>::Lend> { self.next() }
+    fn next_back(&mut self) -> Option<<Self as Lending<'_>>::Lend> {
+        self.next()
+    }
 }
 
 impl<'a, L> ExactSizeLender for Once<'a, L> where L: ?Sized + for<'all> Lending<'all> {}

--- a/src/sources/once_with.rs
+++ b/src/sources/once_with.rs
@@ -41,7 +41,9 @@ where
     F: for<'all> FnOnceHKA<'all, &'all mut St>,
 {
     #[inline]
-    fn next(&mut self) -> Option<<Self as Lending<'_>>::Lend> { self.f.take().map(|f| f(&mut self.state)) }
+    fn next(&mut self) -> Option<<Self as Lending<'_>>::Lend> {
+        self.f.take().map(|f| f(&mut self.state))
+    }
     #[inline]
     fn size_hint(&self) -> (usize, Option<usize>) {
         if self.f.is_some() {
@@ -57,7 +59,9 @@ where
     F: for<'all> FnOnceHKA<'all, &'all mut St>,
 {
     #[inline]
-    fn next_back(&mut self) -> Option<<Self as Lending<'_>>::Lend> { self.next() }
+    fn next_back(&mut self) -> Option<<Self as Lending<'_>>::Lend> {
+        self.next()
+    }
 }
 
 impl<St, F> ExactSizeLender for OnceWith<St, F>
@@ -65,7 +69,9 @@ where
     F: for<'all> FnOnceHKA<'all, &'all mut St>,
 {
     #[inline]
-    fn len(&self) -> usize { self.size_hint().0 }
+    fn len(&self) -> usize {
+        self.size_hint().0
+    }
 }
 
 impl<St, F> FusedLender for OnceWith<St, F> where F: for<'all> FnOnceHKA<'all, &'all mut St> {}

--- a/src/sources/repeat.rs
+++ b/src/sources/repeat.rs
@@ -32,7 +32,7 @@ where
     L: ?Sized + for<'all> Lending<'all> + 'a,
     for<'all> <L as Lending<'all>>::Lend: Clone,
 {
-    type Lend = <L as Lending<'lend>>::Lend;
+    type Lend = Lend<'lend, L>;
 }
 
 impl<'a, L> Lender for Repeat<'a, L>
@@ -46,7 +46,9 @@ where
         Some(unsafe { core::mem::transmute::<<Self as Lending<'a>>::Lend, <Self as Lending<'_>>::Lend>(self.elt.clone()) })
     }
     #[inline]
-    fn advance_by(&mut self, _n: usize) -> Result<(), core::num::NonZeroUsize> { Ok(()) }
+    fn advance_by(&mut self, _n: usize) -> Result<(), core::num::NonZeroUsize> {
+        Ok(())
+    }
 }
 
 impl<'a, L> DoubleEndedLender for Repeat<'a, L>
@@ -55,9 +57,13 @@ where
     for<'all> <L as Lending<'all>>::Lend: Clone,
 {
     #[inline]
-    fn next_back(&mut self) -> Option<<Self as Lending<'_>>::Lend> { self.next() }
+    fn next_back(&mut self) -> Option<<Self as Lending<'_>>::Lend> {
+        self.next()
+    }
     #[inline]
-    fn advance_back_by(&mut self, _n: usize) -> Result<(), core::num::NonZeroUsize> { Ok(()) }
+    fn advance_back_by(&mut self, _n: usize) -> Result<(), core::num::NonZeroUsize> {
+        Ok(())
+    }
 }
 
 impl<'a, L> FusedLender for Repeat<'a, L>

--- a/src/sources/repeat_with.rs
+++ b/src/sources/repeat_with.rs
@@ -33,7 +33,7 @@ where
     L: ?Sized + for<'all> Lending<'all> + 'a,
     F: FnMut() -> <L as Lending<'a>>::Lend,
 {
-    type Lend = <L as Lending<'lend>>::Lend;
+    type Lend = Lend<'lend, L>;
 }
 
 impl<'a, L, F> Lender for RepeatWith<'a, L, F>
@@ -47,7 +47,9 @@ where
         Some(unsafe { core::mem::transmute::<<Self as Lending<'a>>::Lend, <Self as Lending<'_>>::Lend>((self.f)()) })
     }
     #[inline]
-    fn advance_by(&mut self, _n: usize) -> Result<(), core::num::NonZeroUsize> { Ok(()) }
+    fn advance_by(&mut self, _n: usize) -> Result<(), core::num::NonZeroUsize> {
+        Ok(())
+    }
 }
 
 impl<'a, L, F> DoubleEndedLender for RepeatWith<'a, L, F>
@@ -56,9 +58,13 @@ where
     F: FnMut() -> <L as Lending<'a>>::Lend,
 {
     #[inline]
-    fn next_back(&mut self) -> Option<<Self as Lending<'_>>::Lend> { self.next() }
+    fn next_back(&mut self) -> Option<<Self as Lending<'_>>::Lend> {
+        self.next()
+    }
     #[inline]
-    fn advance_back_by(&mut self, _n: usize) -> Result<(), core::num::NonZeroUsize> { Ok(()) }
+    fn advance_back_by(&mut self, _n: usize) -> Result<(), core::num::NonZeroUsize> {
+        Ok(())
+    }
 }
 
 impl<'a, L, F> FusedLender for RepeatWith<'a, L, F>

--- a/src/traits/collect.rs
+++ b/src/traits/collect.rs
@@ -5,7 +5,7 @@ use crate::{Lender, Lending};
 /// struct MyStruct;
 /// impl<L: IntoLender> FromLender<L> for MyStruct
 /// where
-///     L: for<'all> Lending<'all, Lend = &'all mut [u32]>,
+///     L::Lender: for<'all> Lending<'all, Lend = &'all mut [u32]>,
 /// {
 ///     fn from_lender(lender: L) -> Self {
 ///         lender.into_lender().for_each(|lend| drop(lend));
@@ -17,22 +17,26 @@ pub trait FromLender<L: IntoLender>: Sized {
     fn from_lender(lender: L) -> Self;
 }
 /// Documentation is incomplete. Refer to [`core::iter::IntoIterator`] for more information
-pub trait IntoLender: for<'all /* where Self: 'all */> Lending<'all> {
-    type Lender: Lender + for<'all> Lending<'all, Lend = <Self as Lending<'all>>::Lend>;
+pub trait IntoLender {
+    type Lender: Lender;
     fn into_lender(self) -> <Self as IntoLender>::Lender;
 }
 impl<L: Lender> IntoLender for L {
     type Lender = L;
     #[inline]
-    fn into_lender(self) -> L { self }
+    fn into_lender(self) -> L {
+        self
+    }
 }
 /// Documentation is incomplete. Refer to [`core::iter::Extend`] for more information
 pub trait ExtendLender<L: IntoLender> {
     fn extend_lender(&mut self, lender: L);
     /// Extends a collection with exactly one element.
-    fn extend_lender_one(&mut self, item: <L as Lending<'_>>::Lend);
+    fn extend_lender_one(&mut self, item: <L::Lender as Lending<'_>>::Lend);
     /// Reserves capacity in a collection for the given number of additional elements.
     ///
     /// The default implementation does nothing.
-    fn extend_lender_reserve(&mut self, additional: usize) { let _ = additional; }
+    fn extend_lender_reserve(&mut self, additional: usize) {
+        let _ = additional;
+    }
 }

--- a/src/traits/lender.rs
+++ b/src/traits/lender.rs
@@ -980,7 +980,8 @@ pub trait Lender: for<'all /* where Self: 'all */> Lending<'all> {
     /// Documentation is incomplete. Refer to [`Iterator::cmp`] for more information
     fn cmp<L>(self, other: L) -> Ordering
     where
-        L: IntoLender + for<'all> Lending<'all, Lend = <Self as Lending<'all>>::Lend>,
+        L: IntoLender,
+        L::Lender: for<'all> Lending<'all, Lend = <Self as Lending<'all>>::Lend>,
         for <'all> <Self as Lending<'all>>::Lend: Ord,
         Self: Sized,
     {
@@ -991,7 +992,7 @@ pub trait Lender: for<'all /* where Self: 'all */> Lending<'all> {
     where
         Self: Sized,
         L: IntoLender,
-        F: for<'all> FnMut(<Self as Lending<'all>>::Lend, <L as Lending<'all>>::Lend) -> Ordering,
+        F: for<'all> FnMut(<Self as Lending<'all>>::Lend, <L::Lender as Lending<'all>>::Lend) -> Ordering,
     {
         match lender_compare(self, other.into_lender(), move |x, y| match cmp(x, y) {
             Ordering::Equal => ControlFlow::Continue(()),
@@ -1005,7 +1006,7 @@ pub trait Lender: for<'all /* where Self: 'all */> Lending<'all> {
     fn partial_cmp<L>(self, other: L) -> Option<Ordering>
     where
         L: IntoLender,
-        for<'all> <Self as Lending<'all>>::Lend: PartialOrd<<L as Lending<'all>>::Lend>,
+        for<'all> <Self as Lending<'all>>::Lend: PartialOrd<<L::Lender as Lending<'all>>::Lend>,
         Self: Sized,
     {
         self.partial_cmp_by(other, |x, y| x.partial_cmp(&y))
@@ -1015,7 +1016,7 @@ pub trait Lender: for<'all /* where Self: 'all */> Lending<'all> {
     where
         Self: Sized,
         L: IntoLender,
-        F: for<'all> FnMut(<Self as Lending<'all>>::Lend, <L as Lending<'all>>::Lend) -> Option<Ordering>,
+        F: for<'all> FnMut(<Self as Lending<'all>>::Lend, <L::Lender as Lending<'all>>::Lend) -> Option<Ordering>,
     {
         match lender_compare(self, other.into_lender(), move |x, y| match partial_cmp(x, y) {
             Some(Ordering::Equal) => ControlFlow::Continue(()),
@@ -1029,7 +1030,7 @@ pub trait Lender: for<'all /* where Self: 'all */> Lending<'all> {
     fn eq<L>(self, other: L) -> bool
     where
         L: IntoLender,
-        for<'all> <Self as Lending<'all>>::Lend: PartialEq<<L as Lending<'all>>::Lend>,
+        for<'all> <Self as Lending<'all>>::Lend: PartialEq<<L::Lender as Lending<'all>>::Lend>,
         Self: Sized,
     {
         self.eq_by(other, |x, y| x == y)
@@ -1039,7 +1040,7 @@ pub trait Lender: for<'all /* where Self: 'all */> Lending<'all> {
     where
         Self: Sized,
         L: IntoLender,
-        F: for<'all> FnMut(<Self as Lending<'all>>::Lend, <L as Lending<'all>>::Lend) -> bool,
+        F: for<'all> FnMut(<Self as Lending<'all>>::Lend, <L::Lender as Lending<'all>>::Lend) -> bool,
     {
         match lender_compare(self, other.into_lender(), move |x, y| {
             if eq(x, y) { ControlFlow::Continue(()) } else { ControlFlow::Break(()) }
@@ -1052,7 +1053,7 @@ pub trait Lender: for<'all /* where Self: 'all */> Lending<'all> {
     fn ne<L>(self, other: L) -> bool
     where
         L: IntoLender,
-        for<'all> <Self as Lending<'all>>::Lend: PartialEq<<L as Lending<'all>>::Lend>,
+        for<'all> <Self as Lending<'all>>::Lend: PartialEq<<L::Lender as Lending<'all>>::Lend>,
         Self: Sized,
     {
         !self.eq(other)
@@ -1061,7 +1062,7 @@ pub trait Lender: for<'all /* where Self: 'all */> Lending<'all> {
     fn lt<L>(self, other: L) -> bool
     where
         L: IntoLender,
-        for<'all> <Self as Lending<'all>>::Lend: PartialOrd<<L as Lending<'all>>::Lend>,
+        for<'all> <Self as Lending<'all>>::Lend: PartialOrd<<L::Lender as Lending<'all>>::Lend>,
         Self: Sized,
     {
         self.partial_cmp(other) == Some(Ordering::Less)
@@ -1070,7 +1071,7 @@ pub trait Lender: for<'all /* where Self: 'all */> Lending<'all> {
     fn le<L>(self, other: L) -> bool
     where
         L: IntoLender,
-        for<'all> <Self as Lending<'all>>::Lend: PartialOrd<<L as Lending<'all>>::Lend>,
+        for<'all> <Self as Lending<'all>>::Lend: PartialOrd<<L::Lender as Lending<'all>>::Lend>,
         Self: Sized,
     {
         matches!(self.partial_cmp(other), Some(Ordering::Less | Ordering::Equal))
@@ -1079,7 +1080,7 @@ pub trait Lender: for<'all /* where Self: 'all */> Lending<'all> {
     fn gt<L>(self, other: L) -> bool
     where
         L: IntoLender,
-        for<'all> <Self as Lending<'all>>::Lend: PartialOrd<<L as Lending<'all>>::Lend>,
+        for<'all> <Self as Lending<'all>>::Lend: PartialOrd<<L::Lender as Lending<'all>>::Lend>,
         Self: Sized,
     {
         self.partial_cmp(other) == Some(Ordering::Greater)
@@ -1088,7 +1089,7 @@ pub trait Lender: for<'all /* where Self: 'all */> Lending<'all> {
     fn ge<L>(self, other: L) -> bool
     where
         L: IntoLender,
-        for<'all> <Self as Lending<'all>>::Lend: PartialOrd<<L as Lending<'all>>::Lend>,
+        for<'all> <Self as Lending<'all>>::Lend: PartialOrd<<L::Lender as Lending<'all>>::Lend>,
         Self: Sized,
     {
         matches!(self.partial_cmp(other), Some(Ordering::Greater | Ordering::Equal))
@@ -1215,9 +1216,15 @@ impl<'lend, L: Lender> Lending<'lend> for &mut L {
 }
 impl<L: Lender> Lender for &mut L {
     #[inline]
-    fn next(&mut self) -> Option<<Self as Lending<'_>>::Lend> { (**self).next() }
+    fn next(&mut self) -> Option<<Self as Lending<'_>>::Lend> {
+        (**self).next()
+    }
     #[inline]
-    fn size_hint(&self) -> (usize, Option<usize>) { (**self).size_hint() }
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        (**self).size_hint()
+    }
     #[inline]
-    fn advance_by(&mut self, n: usize) -> Result<(), NonZeroUsize> { (**self).advance_by(n) }
+    fn advance_by(&mut self, n: usize) -> Result<(), NonZeroUsize> {
+        (**self).advance_by(n)
+    }
 }

--- a/src/traits/lender.rs
+++ b/src/traits/lender.rs
@@ -27,6 +27,9 @@ pub trait Lending<'lend, __Seal: Sealed = Seal<&'lend Self>> {
     type Lend: 'lend;
 }
 
+/// A readable shorthand for the type of the items of a [`Lender`] `L`.
+pub type Lend<'lend, L> = <L as Lending<'lend>>::Lend;
+
 /// A trait for dealing with lending iterators.
 ///
 /// This is the main lender trait. For more about the concept of lenders
@@ -1212,7 +1215,7 @@ where
     }
 }
 impl<'lend, L: Lender> Lending<'lend> for &mut L {
-    type Lend = <L as Lending<'lend>>::Lend;
+    type Lend = Lend<'lend, L>;
 }
 impl<L: Lender> Lender for &mut L {
     #[inline]

--- a/src/traits/mod.rs
+++ b/src/traits/mod.rs
@@ -10,7 +10,7 @@ pub use self::{
     collect::{ExtendLender, FromLender, IntoLender},
     double_ended::DoubleEndedLender,
     exact_size::ExactSizeLender,
-    lender::{Lender, Lending},
+    lender::{Lend, Lender, Lending},
     marker::FusedLender,
 };
 
@@ -24,19 +24,25 @@ impl<'a, A: 'a, B: 'a> TupleLend<'a> for (A, B) {
     type First = A;
     type Second = B;
     #[inline(always)]
-    fn tuple_lend(self) -> (Self::First, Self::Second) { (self.0, self.1) }
+    fn tuple_lend(self) -> (Self::First, Self::Second) {
+        (self.0, self.1)
+    }
 }
 impl<'a, A, B> TupleLend<'a> for &'a (A, B) {
     type First = &'a A;
     type Second = &'a B;
     #[inline(always)]
-    fn tuple_lend(self) -> (Self::First, Self::Second) { (&self.0, &self.1) }
+    fn tuple_lend(self) -> (Self::First, Self::Second) {
+        (&self.0, &self.1)
+    }
 }
 impl<'a, A, B> TupleLend<'a> for &'a mut (A, B) {
     type First = &'a mut A;
     type Second = &'a mut B;
     #[inline(always)]
-    fn tuple_lend(self) -> (Self::First, Self::Second) { (&mut self.0, &mut self.1) }
+    fn tuple_lend(self) -> (Self::First, Self::Second) {
+        (&mut self.0, &mut self.1)
+    }
 }
 
 /// Internal struct used to implement [`lend!`], do not use directly.

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -10,7 +10,7 @@ impl<'lend, 'a, T> Lending<'lend> for WindowsMut<'a, T> {
     type Lend = &'lend mut [T];
 }
 impl<'a, T> Lender for WindowsMut<'a, T> {
-    fn next<'lend>(&'lend mut self) -> Option<&'lend mut [T]> {
+    fn next(&mut self) -> Option<&mut [T]> {
         let begin = self.begin;
         self.begin = self.begin.saturating_add(1);
         self.slice.get_mut(begin..begin + self.len)
@@ -44,7 +44,7 @@ fn lines_str() {
         type Lend = io::Result<&'lend str>;
     }
     impl<B: io::BufRead> Lender for LinesStr<B> {
-        fn next<'lend>(&'lend mut self) -> Option<io::Result<&'lend str>> {
+        fn next(&mut self) -> Option<io::Result<&str>> {
             self.line.clear();
             match self.buf.read_line(&mut self.line) {
                 Err(e) => return Some(Err(e)),


### PR DESCRIPTION
We are trying to use this crate instead of our [own-made lending iterator crate](https://crates.io/crates/hrtb-lending-iterator) for [the Rust port of WebGraph](https://github.com/vigna/webgraph-rs/) and we ran into a problem.

The way IntoLender is defined requires to specify, again, the type of item lent via a dependency from Lending. So there are now two specifications of the same thing—one in IntoLender, the other one in IntoLender::Lender.

Because of this, we haven't been able to make our methods that receive IntoLender work (they have quite complicated trait bounds). Depending on whether we specify the bounds on IntoLender or on the associated Lender we get different problems, and also specifying both bounds doesn't seem to work.

However, it seems that all that is necessary is to get rid of the dependency of IntoLender from Lending. All trait bounds for the lent item for L: IntoLender can be equivalently rewritten using L::Lender. This reduces the burden on implementors (no need to implement Lending for IntoLender implementations), and is equivalent to specifying twice the requirement in the same way. The change should also be backward-compatible, as existing implementations of Lending for IntoLender implementations will just be useless, but not harming. (Ok, if someone has implemented a method receiving an IntoLender L and has written trait bounds using L as Lending that might require to replace L with L::Lender.)

Finally, this PR adds (similary to our crate) a Lend type
```
pub type Lend<'lend, L> = <L as lender::Lending<'lend>>::Lend;
```
We have a similar alias in our crate and it really helps in making trait bounds readable.

We can of course work with a fork, but we really like this crate and it would be amazing if we could make it work with our code.