### PR TITLE
fix type annotations to not require `Self: 'this`

### DIFF
--- a/src/adapters/intersperse.rs
+++ b/src/adapters/intersperse.rs
@@ -132,7 +132,7 @@ where
             self.needs_sep = false;
             // SAFETY: 'this: 'lend
             Some(unsafe {
-                core::mem::transmute::<<Self as Lending<'this>>::Lend, <Self as Lending<'_>>::Lend>((self.separator)())
+                core::mem::transmute::<<L as Lending<'this>>::Lend, <L as Lending<'_>>::Lend>((self.separator)())
             })
         } else {
             self.needs_sep = true;

--- a/src/sources/from_iter.rs
+++ b/src/sources/from_iter.rs
@@ -175,7 +175,7 @@ where
     #[inline]
     fn next(&mut self) -> Option<Lend<'_, Self>> {
         // SAFETY: 'a: 'lend
-        unsafe { core::mem::transmute::<Option<Lend<'a, Self>>, Option<Lend<'_, Self>>>(self.iter.next()) }
+        unsafe { core::mem::transmute::<Option<Lend<'a, L>>, Option<Lend<'_, L>>>(self.iter.next()) }
     }
     #[inline]
     fn size_hint(&self) -> (usize, Option<usize>) {
@@ -190,7 +190,7 @@ where
 {
     fn next_back(&mut self) -> Option<Lend<'_, Self>> {
         // SAFETY: 'a: 'lend
-        unsafe { core::mem::transmute::<Option<Lend<'a, Self>>, Option<Lend<'_, Self>>>(self.iter.next_back()) }
+        unsafe { core::mem::transmute::<Option<Lend<'a, L>>, Option<Lend<'_, L>>>(self.iter.next_back()) }
     }
 }
 

--- a/src/sources/repeat_with.rs
+++ b/src/sources/repeat_with.rs
@@ -44,7 +44,7 @@ where
     #[inline]
     fn next(&mut self) -> Option<<Self as Lending<'_>>::Lend> {
         // SAFETY: 'a: 'lend
-        Some(unsafe { core::mem::transmute::<<Self as Lending<'a>>::Lend, <Self as Lending<'_>>::Lend>((self.f)()) })
+        Some(unsafe { core::mem::transmute::<<L as Lending<'a>>::Lend, <L as Lending<'_>>::Lend>((self.f)()) })
     }
     #[inline]
     fn advance_by(&mut self, _n: usize) -> Result<(), core::num::NonZeroUsize> {


### PR DESCRIPTION
Hi @WanderLanz,

Just a heads-up, `lender` will stop compiling after a recent soundness fix to the rust compiler in rust-lang/rust#104098. This was found by this [crater run][crater]. The error message can be found [here][msg] and you can try to build `lender` with that change by installing the toolchain first:

[crater]: https://github.com/rust-lang/rust/pull/104098#issuecomment-1807232912
[msg]: https://crater-reports.s3.amazonaws.com/pr-104098/try%236c5ba887f1fae50b77a36ca00e3d7164c1434657/reg/lender-0.2.1/log.txt
```
$ rustup-toolchain-install-master 6c5ba887f1fae50b77a36ca00e3d7164c1434657
$ cargo +6c5ba887f1fae50b77a36ca00e3d7164c1434657 build
```

A minimal example of what has changed in that PR is that the rust compiler used to incorrectly accept the following code:

```rust
trait Lending<'lend, _Witness = &'lend Self> {
    type Lend: 'lend;
}

struct Adapter<G>(G); // e.g. IntersperseWith

impl<'this, G> Lending<'this> for Adapter<G> {
    type Lend = (); // Lend does not depend on G
}

fn next<'this, G>() {
    let _: <Adapter<G> as Lending<'this>>::Lend;
    //~^ ERROR `G` may not live long enough
    // The full type is `<Adapter<G> as Lending<'this, &'this Adapter<G>>>::Lend`
    // The default type `&'this Adapter<G>` should require `T: 'this`
}
```

This can be fixed by adding a where clause `G: 'this` as suggested by the error message. Alternatively we can change the type annotation `<Adapter<G> as Lending<'this>>::Lend` to not require additional lifetime constraints. This is what I've done in this PR because it has the advantage of not breaking the public interface (although the other approach is only a theoretical breaking change. I would be surprised if it breaks real dependent code).
