### PR TITLE
Use `fold` in implementation of `Lender::for_each`

### DIFF
--- a/lender/src/traits/lender.rs
+++ b/lender/src/traits/lender.rs
@@ -338,14 +338,12 @@ pub trait Lender: for<'all /* where Self: 'all */> Lending<'all> {
     /// });
     /// ```
     #[inline]
-    fn for_each<F>(mut self, mut f: F)
+    fn for_each<F>(self, mut f: F)
     where
         Self: Sized,
         F: FnMut(Lend<'_, Self>),
     {
-        while let Some(a) = self.next() {
-            f(a);
-        }
+	self.fold((), |_, t| f(t))
     }
     /// Filter this lender using the given predicate.
     ///


### PR DESCRIPTION
The current implementation of `Lender::for_each` repeatedly calls `next()`. This method can be slower than using `fold()`, especially when iterators implement a custom `fold()` function that exploits properties of their iteration mechanism to iterate faster than enumerating items one at a time with `next()`.

For example, Rust's standard library's `Iterator` also uses `fold()` for their `for_each` implementation:
```rust
    fn for_each<F>(self, f: F)
    where
        Self: Sized,
        F: FnMut(Self::Item),
    {
        #[inline]
        fn call<T>(mut f: impl FnMut(T)) -> impl FnMut((), T) {
            move |(), item| f(item)
        }


        self.fold((), call(f));
    }
```

Unless I have missed the reason why `next()` should be used instead, I think this is a free optimization.