### PR TITLE
Make trybuild a dev-dependency instead of a regular dependency

### DIFF
--- a/lender/Cargo.toml
+++ b/lender/Cargo.toml
@@ -16,6 +16,8 @@ keywords = ["lending", "iterator"]
 [dependencies]
 lender-derive = { version = "0.1.2", optional = true }
 stable_try_trait_v2 = { path = "../stable_try_trait_v2", version = "1.75" }
+
+[dev-dependencies]
 trybuild = "1.0.111"
 
 [features]


### PR DESCRIPTION
Hello!

This is a very minor fork, just to move the `trybuild` dependency to `[dev-dependencies]`, since it is only used in tests.

This reduces the dependency count of crates that depend on `lender`.

If possible, a new version with this change would be appreciated.