### PR TITLE
Fix 'unused lifetime parameter' on lifetimes in with<>

### DIFF
--- a/lender/src/higher_order.rs
+++ b/lender/src/higher_order.rs
@@ -339,7 +339,16 @@ macro_rules! __covar__ {
                     )?
                     $hr
                 >(
-                    ::core::marker::PhantomData<fn() -> ($Ret, &$hr ())>
+                    ::core::marker::PhantomData<
+                        (
+                            fn() -> ($Ret, &$hr ()),
+                            $(
+                                $($(
+                                    &$lt (),
+                                )+)?
+                            )?
+                        )
+                    >
                 );
 
                 // This function only compiles if __CovarCheck (and thus $Ret)

--- a/lender/tests/fail/try_collect.stderr
+++ b/lender/tests/fail/try_collect.stderr
@@ -25,5 +25,5 @@ error: implementation of `lender::FromLender` is not general enough
 40 |     let wrapper: ChangeOutputType<Result<(), _>, _> = lender.try_collect::<Wrapper<TryShunt<'_, _>>>();
    |                                                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ implementation of `lender::FromLender` is not general enough
    |
-   = note: `Wrapper<lender::TryShunt<'2, &mut lender::FromFn<(), {closure@$DIR/src/higher_order.rs:381:15: 381:43}>>>` must implement `lender::FromLender<lender::TryShunt<'1, &mut lender::FromFn<(), {closure@$DIR/src/higher_order.rs:381:15: 381:43}>>>`, for any lifetime `'1`...
-   = note: ...but it actually implements `lender::FromLender<lender::TryShunt<'2, &mut lender::FromFn<(), {closure@$DIR/src/higher_order.rs:381:15: 381:43}>>>`, for some specific lifetime `'2`
+   = note: `Wrapper<lender::TryShunt<'2, &mut lender::FromFn<(), {closure@$DIR/src/higher_order.rs:390:15: 390:43}>>>` must implement `lender::FromLender<lender::TryShunt<'1, &mut lender::FromFn<(), {closure@$DIR/src/higher_order.rs:390:15: 390:43}>>>`, for any lifetime `'1`...
+   = note: ...but it actually implements `lender::FromLender<lender::TryShunt<'2, &mut lender::FromFn<(), {closure@$DIR/src/higher_order.rs:390:15: 390:43}>>>`, for some specific lifetime `'2`


### PR DESCRIPTION
Without it, code like this:

```
my_lender.flat_map(lender::covar_mut!(
    #![with<'g, G: SplitLabeling<Label=usize>>]
    for<'lend>
    move |(src, succ): (usize, <<G as SplitLabeling>::SplitLender<'g> as NodeLabelsLender<'lend>>::IntoIterator)|
    -> lender::FromIter<std::vec::IntoIter<(usize, usize)>> {
```

errors with:

```
error[E0392]: lifetime parameter `'g` is never used
  --> src/compress/transform.rs:79:41
   |
79 | ...                   #![with<'g, G: SplitLabeling<Label=usize>>]
   |                               ^^ unused lifetime parameter
   |
   = help: consider removing `'g`, referring to it in a field, or using a marker such as `std::marker::PhantomData`
```

Fixes regression in 8b3c7cd2be493845e79a65fa3df998fd8919fbe2.