### PR TITLE
Fix soundness, correctness, and panic bugs found in review

### DIFF
--- a/lender/src/adapters/chunky.rs
+++ b/lender/src/adapters/chunky.rs
@@ -130,10 +130,7 @@ where
         } else {
             // Exhaust
             if self.len > 0 {
-                let skip = self
-                    .len
-                    .checked_mul(self.chunk_size)
-                    .expect("overflow in Chunky::nth");
+                let skip = self.len.saturating_mul(self.chunk_size);
                 let _ = self.lender.advance_by(skip);
                 self.len = 0;
             }
@@ -197,3 +194,36 @@ impl<L> FusedLender for Chunky<L> where L: FusedLender {}
 // `next()` will actually produce. This violates the ExactSizeLender
 // contract, which requires `len()` to match the actual remaining
 // count. The chunk count is still available through `size_hint()`.
+
+#[cfg(test)]
+mod test {
+    use crate::prelude::*;
+
+    // A lender reporting len() == usize::MAX with O(1) advance_by, to exercise the
+    // exhaust branch's chunk-count * chunk_size multiplication near usize::MAX.
+    struct Huge;
+    impl<'l> crate::Lending<'l> for Huge {
+        type Lend = i32;
+    }
+    impl crate::Lender for Huge {
+        crate::check_covariance!();
+        fn next(&mut self) -> Option<crate::Lend<'_, Self>> {
+            Some(0)
+        }
+        fn advance_by(&mut self, _n: usize) -> Result<(), core::num::NonZeroUsize> {
+            Ok(())
+        }
+    }
+    impl crate::ExactSizeLender for Huge {
+        fn len(&self) -> usize {
+            usize::MAX
+        }
+    }
+
+    #[test]
+    fn test_nth_exhaust_no_overflow_panic() {
+        // len = usize::MAX.div_ceil(2); nth past the end must not panic on len * 2 overflow
+        let mut c = Huge.chunky(2);
+        assert!(c.nth(usize::MAX).is_none());
+    }
+}

--- a/lender/src/adapters/flatten.rs
+++ b/lender/src/adapters/flatten.rs
@@ -30,7 +30,8 @@ where
 
     /// Returns the inner lender.
     #[inline]
-    pub fn into_inner(self) -> L {
+    pub fn into_inner(mut self) -> L {
+        *self.inner.inner = None;
         *AliasableBox::into_unique(self.inner.lender)
     }
 }
@@ -133,13 +134,15 @@ where
 
     /// Returns the inner lender.
     #[inline]
-    pub fn into_inner(self) -> L {
+    pub fn into_inner(mut self) -> L {
+        *self.inner.inner = None;
         (*AliasableBox::into_unique(self.inner.lender)).into_inner()
     }
 
     /// Returns the inner lender and the mapping function.
     #[inline]
-    pub fn into_parts(self) -> (L, Covar<F>) {
+    pub fn into_parts(mut self) -> (L, Covar<F>) {
+        *self.inner.inner = None;
         (*AliasableBox::into_unique(self.inner.lender)).into_parts()
     }
 }

--- a/lender/src/adapters/fuse.rs
+++ b/lender/src/adapters/fuse.rs
@@ -77,12 +77,11 @@ where
         Self: Sized,
     {
         if !self.flag {
-            if let x @ Some(_) = self.lender.last() {
-                return x;
-            }
             self.flag = true;
+            self.lender.last()
+        } else {
+            None
         }
-        None
     }
 
     #[inline]
@@ -242,5 +241,38 @@ impl<L: Default + Lender> Default for Fuse<L> {
     #[inline]
     fn default() -> Self {
         Fuse::new(L::default())
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use crate::prelude::*;
+
+    // A non-fused lender: yields 10, then None, then 30 if polled again.
+    struct Resurrect {
+        step: usize,
+    }
+    impl<'l> crate::Lending<'l> for Resurrect {
+        type Lend = i32;
+    }
+    impl crate::Lender for Resurrect {
+        crate::check_covariance!();
+        fn next(&mut self) -> Option<crate::Lend<'_, Self>> {
+            let s = self.step;
+            self.step += 1;
+            match s {
+                0 => Some(10),
+                2 => Some(30),
+                _ => None,
+            }
+        }
+    }
+
+    #[test]
+    fn test_last_fuses() {
+        let mut f = (Resurrect { step: 0 }).fuse();
+        assert_eq!(f.last(), Some(10)); // drives the inner lender to None
+        assert_eq!(f.next(), None); // must stay fused, not resurrect 30
+        assert_eq!(f.size_hint(), (0, Some(0)));
     }
 }

--- a/lender/src/adapters/peekable.rs
+++ b/lender/src/adapters/peekable.rs
@@ -41,7 +41,8 @@ where
 
     /// Returns the inner lender.
     #[inline]
-    pub fn into_inner(self) -> L {
+    pub fn into_inner(mut self) -> L {
+        *self.peeked = None;
         *AliasableBox::into_unique(self.lender)
     }
 
@@ -242,12 +243,13 @@ where
 
     #[inline]
     fn count(mut self) -> usize {
+        let extra = match self.peeked.take() {
+            Some(None) => return 0,
+            Some(Some(_)) => 1,
+            None => 0,
+        };
         let lender = *AliasableBox::into_unique(self.lender);
-        match self.peeked.take() {
-            Some(None) => 0,
-            Some(Some(_)) => 1 + lender.count(),
-            None => lender.count(),
-        }
+        extra + lender.count()
     }
 
     #[inline]
@@ -446,5 +448,18 @@ mod test {
             peeked, array,
             "Peeked element pointer should point to the first element of the array"
         );
+    }
+
+    #[test]
+    fn test_into_inner_and_count_after_peek() {
+        use crate::prelude::*;
+        let mut p = [1, 2, 3].iter().into_lender().peekable();
+        assert_eq!(p.peek(), Some(&&1));
+        assert_eq!(p.count(), 3); // peeked element counted, no panic/UB
+
+        let mut p = [1, 2, 3].iter().into_lender().peekable();
+        assert_eq!(p.peek(), Some(&&1));
+        let mut inner = p.into_inner(); // must not free-then-drop the cache
+        assert_eq!(inner.next(), Some(&2)); // peeked &1 consumed into the (now-dropped) cache
     }
 }

--- a/lender/src/adapters/peekable.rs
+++ b/lender/src/adapters/peekable.rs
@@ -97,15 +97,25 @@ where
     /// # use lender::prelude::*;
     /// let mut lender = [1, 2, 3].iter().into_lender().peekable();
     ///
-    /// if let Some(p) = lender.peek_mut() {
+    /// // SAFETY: `p` is used and dropped within this scope; the lend never escapes the borrow.
+    /// if let Some(p) = unsafe { lender.peek_mut() } {
     ///     // p is &mut &i32, so we replace the reference
     ///     *p = &10;
     /// }
     /// assert_eq!(lender.next(), Some(&10));
     /// assert_eq!(lender.next(), Some(&2));
     /// ```
+    ///
+    /// # Safety
+    ///
+    /// The returned reference exposes the cached lend with the lender's full
+    /// storage lifetime. The caller must not, through the returned reference,
+    /// (a) move or copy out a lend that outlives this `&mut self` borrow, nor
+    /// (b) overwrite the referent with a lend borrowing data that does not
+    /// outlive this `Peekable`. Either lets the lend escape its borrow, causing
+    /// a use-after-free.
     #[inline]
-    pub fn peek_mut(&mut self) -> Option<&'_ mut Lend<'this, L>> {
+    pub unsafe fn peek_mut(&mut self) -> Option<&'_ mut Lend<'this, L>> {
         let lender = &mut self.lender;
         self.peeked
             .get_or_insert_with(|| {

--- a/lender/src/adapters/step_by.rs
+++ b/lender/src/adapters/step_by.rs
@@ -86,6 +86,7 @@ where
             if n == 0 {
                 return self.lender.next();
             }
+            let _ = self.lender.next();
             n -= 1;
         }
         let mut step = self.step + 1;
@@ -248,3 +249,16 @@ where
 impl<L> ExactSizeLender for StepBy<L> where L: ExactSizeLender {}
 
 impl<L> FusedLender for StepBy<L> where L: FusedLender {}
+
+#[cfg(test)]
+mod test {
+    use crate::prelude::*;
+    #[test]
+    fn test_nth_fresh() {
+        // yields &0,&2,&4; nth(1) is the SECOND yielded element = &2 (was &1 before the fix)
+        let mut s = [0, 1, 2, 3, 4].iter().into_lender().step_by(2);
+        assert_eq!(s.nth(1), Some(&2));
+        // matches std::iter::StepBy
+        assert_eq!((0..5).step_by(2).nth(1), Some(2));
+    }
+}

--- a/lender/src/adapters/take.rs
+++ b/lender/src/adapters/take.rs
@@ -180,7 +180,7 @@ where
             self.n -= n + 1;
             self.lender.nth_back(m)
         } else {
-            if len > 0 {
+            if self.n != 0 && len > 0 {
                 self.lender.nth_back(len - 1);
             }
             None
@@ -230,6 +230,9 @@ where
 
     #[inline]
     fn advance_back_by(&mut self, n: usize) -> Result<(), NonZeroUsize> {
+        if n == 0 {
+            return Ok(());
+        }
         // Relies on ExactSizeLender: if len() is inaccurate,
         // advanced_by_inner - trim_inner may underflow.
         let trim_inner = self.lender.len().saturating_sub(self.n);
@@ -248,3 +251,33 @@ where
 impl<L> ExactSizeLender for Take<L> where L: ExactSizeLender {}
 
 impl<L> FusedLender for Take<L> where L: FusedLender {}
+
+#[cfg(test)]
+mod test {
+    use crate::prelude::*;
+
+    #[test]
+    fn test_advance_back_by_zero_is_noop() {
+        let mut t = [0, 1, 2, 3].iter().into_lender().take(2);
+        assert!(t.advance_back_by(0).is_ok());
+        // inner must be untouched: all four elements remain
+        let mut inner = t.into_inner();
+        assert_eq!(inner.next(), Some(&0));
+        assert_eq!(inner.next(), Some(&1));
+        assert_eq!(inner.next(), Some(&2));
+        assert_eq!(inner.next(), Some(&3));
+        assert_eq!(inner.next(), None);
+    }
+
+    #[test]
+    fn test_empty_take_nth_back_leaves_inner() {
+        let mut t = [0, 1, 2, 3].iter().into_lender().take(0);
+        assert_eq!(t.nth_back(0), None);
+        let mut inner = t.into_inner();
+        assert_eq!(inner.next(), Some(&0));
+        assert_eq!(inner.next(), Some(&1));
+        assert_eq!(inner.next(), Some(&2));
+        assert_eq!(inner.next(), Some(&3));
+        assert_eq!(inner.next(), None);
+    }
+}

--- a/lender/src/adapters/take_while.rs
+++ b/lender/src/adapters/take_while.rs
@@ -68,11 +68,10 @@ where
     #[inline]
     fn next(&mut self) -> Option<Lend<'_, Self>> {
         if !self.flag {
-            let x = self.lender.next()?;
-            if (self.predicate)(&x) {
-                return Some(x);
+            match self.lender.next() {
+                Some(x) if (self.predicate)(&x) => return Some(x),
+                _ => self.flag = true,
             }
-            self.flag = true;
         }
         None
     }
@@ -144,4 +143,37 @@ where
     P: FnMut(&Lend<'_, L>) -> bool,
     L: Lender,
 {
+}
+
+#[cfg(test)]
+mod test {
+    use crate::prelude::*;
+
+    // A non-fused lender: yields 10, then None, then 30 if polled again.
+    struct Resurrect {
+        step: usize,
+    }
+    impl<'l> crate::Lending<'l> for Resurrect {
+        type Lend = i32;
+    }
+    impl crate::Lender for Resurrect {
+        crate::check_covariance!();
+        fn next(&mut self) -> Option<crate::Lend<'_, Self>> {
+            let s = self.step;
+            self.step += 1;
+            match s {
+                0 => Some(10),
+                2 => Some(30),
+                _ => None,
+            }
+        }
+    }
+
+    #[test]
+    fn test_none_is_terminal() {
+        let mut tw = (Resurrect { step: 0 }).take_while(|_| true);
+        assert_eq!(tw.next(), Some(10));
+        assert_eq!(tw.next(), None); // inner yields None -> TakeWhile is done
+        assert_eq!(tw.next(), None); // must not resurrect 30 (TakeWhile is FusedLender)
+    }
 }

--- a/lender/src/fallible_adapters/chunky.rs
+++ b/lender/src/fallible_adapters/chunky.rs
@@ -44,10 +44,7 @@ where
         } else {
             // Exhaust
             if self.len > 0 {
-                let skip = self
-                    .len
-                    .checked_mul(self.chunk_size)
-                    .expect("overflow in Chunky::nth");
+                let skip = self.len.saturating_mul(self.chunk_size);
                 let _ = self.lender.advance_by(skip)?;
                 self.len = 0;
             }
@@ -101,3 +98,42 @@ where
 }
 
 impl<L> FusedFallibleLender for Chunky<L> where L: FusedFallibleLender {}
+
+#[cfg(test)]
+mod test {
+    use core::convert::Infallible;
+
+    use crate::prelude::*;
+
+    // A fallible lender reporting len() == usize::MAX with O(1) advance_by.
+    struct Huge;
+    impl<'l> crate::FallibleLending<'l> for Huge {
+        type Lend = i32;
+    }
+    impl crate::FallibleLender for Huge {
+        type Error = Infallible;
+        crate::check_covariance_fallible!();
+        fn next(&mut self) -> Result<Option<crate::FallibleLend<'_, Self>>, Self::Error> {
+            Ok(Some(0))
+        }
+        fn advance_by(
+            &mut self,
+            _n: usize,
+        ) -> Result<Result<(), core::num::NonZeroUsize>, Self::Error> {
+            Ok(Ok(()))
+        }
+    }
+    impl crate::ExactSizeFallibleLender for Huge {
+        fn len(&self) -> usize {
+            usize::MAX
+        }
+    }
+
+    #[test]
+    fn test_nth_exhaust_no_overflow_panic() -> Result<(), Infallible> {
+        // len = usize::MAX.div_ceil(2); nth past the end must not panic on len * 2 overflow
+        let mut c = Huge.chunky(2);
+        assert!(c.nth(usize::MAX)?.is_none());
+        Ok(())
+    }
+}

--- a/lender/src/fallible_adapters/flatten.rs
+++ b/lender/src/fallible_adapters/flatten.rs
@@ -33,7 +33,8 @@ where
 
     /// Returns the inner lender.
     #[inline]
-    pub fn into_inner(self) -> L {
+    pub fn into_inner(mut self) -> L {
+        *self.inner.inner = None;
         *AliasableBox::into_unique(self.inner.lender)
     }
 }
@@ -141,13 +142,15 @@ where
 
     /// Returns the inner lender.
     #[inline]
-    pub fn into_inner(self) -> L {
+    pub fn into_inner(mut self) -> L {
+        *self.inner.inner = None;
         (*AliasableBox::into_unique(self.inner.lender)).into_inner()
     }
 
     /// Returns the inner lender and the mapping function.
     #[inline]
-    pub fn into_parts(self) -> (L, Covar<F>) {
+    pub fn into_parts(mut self) -> (L, Covar<F>) {
+        *self.inner.inner = None;
         (*AliasableBox::into_unique(self.inner.lender)).into_parts()
     }
 }
@@ -483,5 +486,39 @@ mod test {
         assert_eq!(l.next(), Ok(Some(1)));
         assert_eq!(l.next(), Ok(None));
         assert_eq!(l.next(), Ok(None));
+    }
+
+    #[test]
+    fn test_flatten_into_inner() -> Result<(), Infallible> {
+        let mut flatten = Parent([0, 1, 2, 3]).into_fallible().flatten();
+        let _ = flatten.next()?; // populate the sub-lender cache
+        let _inner = flatten.into_inner(); // must clear cache before freeing the box
+        Ok(())
+    }
+
+    #[test]
+    fn test_flat_map_into_inner_and_parts() {
+        use crate::traits::IteratorExt;
+        let mut l = [1, 2]
+            .into_iter()
+            .into_lender()
+            .into_fallible()
+            // SAFETY: closure returns an owned Result (trivially covariant).
+            .flat_map(unsafe {
+                crate::Covar::__new(|n: i32| Ok((0..n).into_lender().into_fallible()))
+            });
+        let _ = l.next(); // populate the sub-lender cache
+        let _inner = l.into_inner(); // must clear cache before freeing the box
+
+        let mut l = [1, 2]
+            .into_iter()
+            .into_lender()
+            .into_fallible()
+            // SAFETY: closure returns an owned Result (trivially covariant).
+            .flat_map(unsafe {
+                crate::Covar::__new(|n: i32| Ok((0..n).into_lender().into_fallible()))
+            });
+        let _ = l.next();
+        let (_inner, _f) = l.into_parts();
     }
 }

--- a/lender/src/fallible_adapters/fuse.rs
+++ b/lender/src/fallible_adapters/fuse.rs
@@ -60,12 +60,11 @@ where
         Self: Sized,
     {
         if !self.flag {
-            if let x @ Some(_) = self.lender.last()? {
-                return Ok(x);
-            }
             self.flag = true;
+            self.lender.last()
+        } else {
+            Ok(None)
         }
-        Ok(None)
     }
 
     #[inline]
@@ -218,3 +217,40 @@ where
 }
 
 impl<L> FusedFallibleLender for Fuse<L> where L: FallibleLender {}
+
+#[cfg(test)]
+mod test {
+    use core::convert::Infallible;
+
+    use crate::prelude::*;
+
+    // A non-fused fallible lender: yields 10, then None, then 30 if polled again.
+    struct Resurrect {
+        step: usize,
+    }
+    impl<'l> crate::FallibleLending<'l> for Resurrect {
+        type Lend = i32;
+    }
+    impl crate::FallibleLender for Resurrect {
+        type Error = Infallible;
+        crate::check_covariance_fallible!();
+        fn next(&mut self) -> Result<Option<crate::FallibleLend<'_, Self>>, Self::Error> {
+            let s = self.step;
+            self.step += 1;
+            Ok(match s {
+                0 => Some(10),
+                2 => Some(30),
+                _ => None,
+            })
+        }
+    }
+
+    #[test]
+    fn test_last_fuses() -> Result<(), Infallible> {
+        let mut f = (Resurrect { step: 0 }).fuse();
+        assert_eq!(f.last()?, Some(10)); // drives the inner lender to None
+        assert_eq!(f.next()?, None); // must stay fused, not resurrect 30
+        assert_eq!(f.size_hint(), (0, Some(0)));
+        Ok(())
+    }
+}

--- a/lender/src/fallible_adapters/peekable.rs
+++ b/lender/src/fallible_adapters/peekable.rs
@@ -121,7 +121,8 @@ where
     ///     .into_fallible()
     ///     .peekable();
     ///
-    /// if let Some(p) = lender.peek_mut()? {
+    /// // SAFETY: `p` is used and dropped within this scope; the lend never escapes the borrow.
+    /// if let Some(p) = unsafe { lender.peek_mut() }? {
     ///     // p is &mut &i32, so we replace the reference
     ///     *p = &10;
     /// }
@@ -130,8 +131,17 @@ where
     /// # Ok(())
     /// # }
     /// ```
+    ///
+    /// # Safety
+    ///
+    /// The returned reference exposes the cached lend with the fallible lender's
+    /// full storage lifetime. The caller must not, through the returned reference,
+    /// (a) move or copy out a lend that outlives this `&mut self` borrow, nor
+    /// (b) overwrite the referent with a lend borrowing data that does not
+    /// outlive this `FalliblePeekable`. Either lets the lend escape its borrow,
+    /// causing a use-after-free.
     #[inline]
-    pub fn peek_mut(&mut self) -> Result<Option<&'_ mut FallibleLend<'this, L>>, L::Error> {
+    pub unsafe fn peek_mut(&mut self) -> Result<Option<&'_ mut FallibleLend<'this, L>>, L::Error> {
         let lender = &mut self.lender;
         if self.peeked.is_none() {
             *self.peeked = Some(

--- a/lender/src/fallible_adapters/peekable.rs
+++ b/lender/src/fallible_adapters/peekable.rs
@@ -44,7 +44,8 @@ where
 
     /// Returns the inner lender.
     #[inline]
-    pub fn into_inner(self) -> L {
+    pub fn into_inner(mut self) -> L {
+        *self.peeked = None;
         *AliasableBox::into_unique(self.lender)
     }
 
@@ -306,12 +307,13 @@ where
 
     #[inline]
     fn count(mut self) -> Result<usize, Self::Error> {
+        let extra = match self.peeked.take() {
+            Some(None) => return Ok(0),
+            Some(Some(_)) => 1,
+            None => 0,
+        };
         let lender = *AliasableBox::into_unique(self.lender);
-        match self.peeked.take() {
-            Some(None) => Ok(0),
-            Some(Some(_)) => Ok(1 + lender.count()?),
-            None => lender.count(),
-        }
+        Ok(extra + lender.count()?)
     }
 
     #[inline]
@@ -529,5 +531,19 @@ mod test {
             peeked, array,
             "Peeked element pointer should point to the first element of the array"
         );
+    }
+
+    #[test]
+    fn test_into_inner_and_count_after_peek() -> Result<(), Infallible> {
+        use crate::prelude::*;
+        let mut p = [1, 2, 3].iter().into_lender().into_fallible().peekable();
+        assert_eq!(p.peek()?, Some(&&1));
+        assert_eq!(p.count()?, 3); // peeked element counted via the Ok/? path
+
+        let mut p = [1, 2, 3].iter().into_lender().into_fallible().peekable();
+        assert_eq!(p.peek()?, Some(&&1));
+        let mut inner = p.into_inner(); // must clear the cache before freeing the box
+        assert_eq!(inner.next()?, Some(&2));
+        Ok(())
     }
 }

--- a/lender/src/fallible_adapters/step_by.rs
+++ b/lender/src/fallible_adapters/step_by.rs
@@ -63,6 +63,7 @@ where
             if n == 0 {
                 return self.lender.next();
             }
+            let _ = self.lender.next()?;
             n -= 1;
         }
         let mut step = self.step + 1;
@@ -227,3 +228,21 @@ where
 impl<L> ExactSizeFallibleLender for StepBy<L> where L: ExactSizeFallibleLender {}
 
 impl<L> FusedFallibleLender for StepBy<L> where L: FusedFallibleLender {}
+
+#[cfg(test)]
+mod test {
+    use core::convert::Infallible;
+
+    use crate::prelude::*;
+    #[test]
+    fn test_nth_fresh() -> Result<(), Infallible> {
+        // yields &0,&2,&4; nth(1) is the SECOND yielded element = &2 (was &1 before the fix)
+        let mut s = [0, 1, 2, 3, 4]
+            .iter()
+            .into_lender()
+            .into_fallible()
+            .step_by(2);
+        assert_eq!(s.nth(1)?, Some(&2));
+        Ok(())
+    }
+}

--- a/lender/src/fallible_adapters/take.rs
+++ b/lender/src/fallible_adapters/take.rs
@@ -160,7 +160,7 @@ where
             self.n -= n + 1;
             self.lender.nth_back(m)
         } else {
-            if len > 0 {
+            if self.n != 0 && len > 0 {
                 self.lender.nth_back(len - 1)?;
             }
             Ok(None)
@@ -210,6 +210,9 @@ where
 
     #[inline]
     fn advance_back_by(&mut self, n: usize) -> Result<Result<(), NonZeroUsize>, Self::Error> {
+        if n == 0 {
+            return Ok(Ok(()));
+        }
         let trim_inner = self.lender.len().saturating_sub(self.n);
         let advance_by = trim_inner.saturating_add(n);
         let remainder = match self.lender.advance_back_by(advance_by)? {
@@ -226,3 +229,37 @@ where
 impl<L> ExactSizeFallibleLender for Take<L> where L: ExactSizeFallibleLender {}
 
 impl<L> FusedFallibleLender for Take<L> where L: FusedFallibleLender {}
+
+#[cfg(test)]
+mod test {
+    use core::convert::Infallible;
+
+    use crate::prelude::*;
+
+    #[test]
+    fn test_advance_back_by_zero_is_noop() -> Result<(), Infallible> {
+        let mut t = [0, 1, 2, 3].iter().into_lender().into_fallible().take(2);
+        assert!(t.advance_back_by(0)?.is_ok());
+        // inner must be untouched: all four elements remain
+        let mut inner = t.into_inner();
+        assert_eq!(inner.next()?, Some(&0));
+        assert_eq!(inner.next()?, Some(&1));
+        assert_eq!(inner.next()?, Some(&2));
+        assert_eq!(inner.next()?, Some(&3));
+        assert_eq!(inner.next()?, None);
+        Ok(())
+    }
+
+    #[test]
+    fn test_empty_take_nth_back_leaves_inner() -> Result<(), Infallible> {
+        let mut t = [0, 1, 2, 3].iter().into_lender().into_fallible().take(0);
+        assert_eq!(t.nth_back(0)?, None);
+        let mut inner = t.into_inner();
+        assert_eq!(inner.next()?, Some(&0));
+        assert_eq!(inner.next()?, Some(&1));
+        assert_eq!(inner.next()?, Some(&2));
+        assert_eq!(inner.next()?, Some(&3));
+        assert_eq!(inner.next()?, None);
+        Ok(())
+    }
+}

--- a/lender/src/fallible_adapters/take_while.rs
+++ b/lender/src/fallible_adapters/take_while.rs
@@ -39,7 +39,10 @@ where
         if !self.flag {
             let x = match self.lender.next()? {
                 Some(x) => x,
-                None => return Ok(None),
+                None => {
+                    self.flag = true;
+                    return Ok(None);
+                }
             };
             if (self.predicate)(&x)? {
                 return Ok(Some(x));
@@ -121,4 +124,41 @@ where
     P: FnMut(&FallibleLend<'_, L>) -> Result<bool, L::Error>,
     L: FallibleLender,
 {
+}
+
+#[cfg(test)]
+mod test {
+    use core::convert::Infallible;
+
+    use crate::prelude::*;
+
+    // A non-fused fallible lender: yields 10, then None, then 30 if polled again.
+    struct Resurrect {
+        step: usize,
+    }
+    impl<'l> crate::FallibleLending<'l> for Resurrect {
+        type Lend = i32;
+    }
+    impl crate::FallibleLender for Resurrect {
+        type Error = Infallible;
+        crate::check_covariance_fallible!();
+        fn next(&mut self) -> Result<Option<crate::FallibleLend<'_, Self>>, Self::Error> {
+            let s = self.step;
+            self.step += 1;
+            Ok(match s {
+                0 => Some(10),
+                2 => Some(30),
+                _ => None,
+            })
+        }
+    }
+
+    #[test]
+    fn test_none_is_terminal() -> Result<(), Infallible> {
+        let mut tw = (Resurrect { step: 0 }).take_while(|_| Ok(true));
+        assert_eq!(tw.next()?, Some(10));
+        assert_eq!(tw.next()?, None); // inner yields None -> TakeWhile is done
+        assert_eq!(tw.next()?, None); // must not resurrect 30 (TakeWhile is FusedFallibleLender)
+        Ok(())
+    }
 }

--- a/lender/src/fallible_sources/from_iter_ref.rs
+++ b/lender/src/fallible_sources/from_iter_ref.rs
@@ -60,6 +60,7 @@ impl<I: FallibleIterator> FallibleLender for FromIterRef<I> {
 
     #[inline]
     fn next(&mut self) -> Result<Option<FallibleLend<'_, Self>>, Self::Error> {
+        self.current = None;
         self.current = self.iter.next()?;
         Ok(self.current.as_ref())
     }
@@ -71,6 +72,7 @@ impl<I: FallibleIterator> FallibleLender for FromIterRef<I> {
 
     #[inline]
     fn nth(&mut self, n: usize) -> Result<Option<FallibleLend<'_, Self>>, Self::Error> {
+        self.current = None;
         self.current = self.iter.nth(n)?;
         Ok(self.current.as_ref())
     }
@@ -134,6 +136,7 @@ impl<I: FallibleIterator> FallibleLender for FromIterRef<I> {
 impl<I: DoubleEndedFallibleIterator> DoubleEndedFallibleLender for FromIterRef<I> {
     #[inline]
     fn next_back(&mut self) -> Result<Option<FallibleLend<'_, Self>>, Self::Error> {
+        self.current = None;
         self.current = self.iter.next_back()?;
         Ok(self.current.as_ref())
     }
@@ -183,5 +186,44 @@ impl<I: FallibleIterator> From<I> for FromIterRef<I> {
     #[inline]
     fn from(iter: I) -> Self {
         from_iter_ref(iter)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use core::cell::{RefCell, RefMut};
+    use core::convert::Infallible;
+
+    use fallible_iterator::FallibleIterator;
+
+    use super::from_iter_ref;
+    use crate::FallibleLender;
+
+    // A fallible iterator whose items each hold an exclusive borrow of `cell`.
+    struct BorrowIter<'a> {
+        cell: &'a RefCell<i32>,
+        n: usize,
+    }
+    impl<'a> FallibleIterator for BorrowIter<'a> {
+        type Item = RefMut<'a, i32>;
+        type Error = Infallible;
+        fn next(&mut self) -> Result<Option<Self::Item>, Self::Error> {
+            if self.n == 0 {
+                return Ok(None);
+            }
+            self.n -= 1;
+            Ok(Some(self.cell.borrow_mut()))
+        }
+    }
+
+    #[test]
+    fn test_drops_previous_item_before_fetch() -> Result<(), Infallible> {
+        let cell = RefCell::new(0);
+        let mut l = from_iter_ref(BorrowIter { cell: &cell, n: 3 });
+        assert!(l.next()?.is_some());
+        assert!(l.next()?.is_some()); // buggy code panics "already mutably borrowed"
+        assert!(l.next()?.is_some());
+        assert!(l.next()?.is_none());
+        Ok(())
     }
 }

--- a/lender/src/sources/from_iter_ref.rs
+++ b/lender/src/sources/from_iter_ref.rs
@@ -54,6 +54,7 @@ impl<I: Iterator> Lender for FromIterRef<I> {
 
     #[inline]
     fn next(&mut self) -> Option<Lend<'_, Self>> {
+        self.current = None;
         self.current = self.iter.next();
         self.current.as_ref()
     }
@@ -65,6 +66,7 @@ impl<I: Iterator> Lender for FromIterRef<I> {
 
     #[inline]
     fn nth(&mut self, n: usize) -> Option<Lend<'_, Self>> {
+        self.current = None;
         self.current = self.iter.nth(n);
         self.current.as_ref()
     }
@@ -129,12 +131,14 @@ impl<I: Iterator> Lender for FromIterRef<I> {
 impl<I: DoubleEndedIterator> DoubleEndedLender for FromIterRef<I> {
     #[inline]
     fn next_back(&mut self) -> Option<Lend<'_, Self>> {
+        self.current = None;
         self.current = self.iter.next_back();
         self.current.as_ref()
     }
 
     #[inline]
     fn nth_back(&mut self, n: usize) -> Option<Lend<'_, Self>> {
+        self.current = None;
         self.current = self.iter.nth_back(n);
         self.current.as_ref()
     }
@@ -189,5 +193,39 @@ impl<I: Iterator> From<I> for FromIterRef<I> {
     #[inline]
     fn from(iter: I) -> Self {
         from_iter_ref(iter)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use core::cell::{RefCell, RefMut};
+
+    use super::from_iter_ref;
+    use crate::Lender;
+
+    // An iterator whose items each hold an exclusive borrow of `cell`.
+    struct BorrowIter<'a> {
+        cell: &'a RefCell<i32>,
+        n: usize,
+    }
+    impl<'a> Iterator for BorrowIter<'a> {
+        type Item = RefMut<'a, i32>;
+        fn next(&mut self) -> Option<Self::Item> {
+            if self.n == 0 {
+                return None;
+            }
+            self.n -= 1;
+            Some(self.cell.borrow_mut())
+        }
+    }
+
+    #[test]
+    fn test_drops_previous_item_before_fetch() {
+        let cell = RefCell::new(0);
+        let mut l = from_iter_ref(BorrowIter { cell: &cell, n: 3 });
+        assert!(l.next().is_some());
+        assert!(l.next().is_some()); // buggy code panics "already mutably borrowed"
+        assert!(l.next().is_some());
+        assert!(l.next().is_none());
     }
 }

--- a/lender/src/traits/fallible_lender.rs
+++ b/lender/src/traits/fallible_lender.rs
@@ -140,8 +140,9 @@ pub trait FallibleLender: for<'all /* where Self: 'all */> FallibleLending<'all>
     fn next(&mut self) -> Result<Option<FallibleLend<'_, Self>>, Self::Error>;
 
     /// Takes the next `chunk_size` lends of the lender with temporary lender
-    /// [`Chunk`]. This is equivalent to cloning the lender and calling
-    /// [`take(chunk_size)`](FallibleLender::take) on it.
+    /// [`Chunk`]. The returned [`Chunk`] borrows this fallible lender mutably
+    /// and advances it as the chunk is consumed; any elements left unconsumed
+    /// when the [`Chunk`] is dropped remain and are produced by later calls.
     ///
     /// # Examples
     ///

--- a/lender/src/traits/lender.rs
+++ b/lender/src/traits/lender.rs
@@ -136,8 +136,9 @@ pub trait Lender: for<'all /* where Self: 'all */> Lending<'all> {
     /// ```
     fn next(&mut self) -> Option<Lend<'_, Self>>;
     /// Takes the next `chunk_size` lends of the lender with temporary lender
-    /// [`Chunk`]. This is equivalent to cloning the lender and calling
-    /// [`take(chunk_size)`](Lender::take) on it.
+    /// [`Chunk`]. The returned [`Chunk`] borrows this lender mutably and
+    /// advances it as the chunk is consumed; any elements left unconsumed when
+    /// the [`Chunk`] is dropped remain and are produced by later calls.
     ///
     /// # Examples
     ///

--- a/lender/tests/fail/peekable_peek_mut_requires_unsafe.rs
+++ b/lender/tests/fail/peekable_peek_mut_requires_unsafe.rs
@@ -1,0 +1,10 @@
+// Test that Peekable::peek_mut cannot be called from safe code: it is `unsafe`
+// because the returned reference exposes the cached lend with the lender's full
+// storage lifetime, allowing a lend to escape its borrow (use-after-free).
+
+use lender::prelude::*;
+
+fn main() {
+    let mut p = [1, 2, 3].iter().into_lender().peekable();
+    let _ = p.peek_mut(); // ERROR: call to unsafe function is unsafe and requires unsafe block
+}

--- a/lender/tests/fail/peekable_peek_mut_requires_unsafe.stderr
+++ b/lender/tests/fail/peekable_peek_mut_requires_unsafe.stderr
@@ -1,0 +1,7 @@
+error[E0133]: call to unsafe function `lender::Peekable::<'this, L>::peek_mut` is unsafe and requires unsafe block
+ --> tests/fail/peekable_peek_mut_requires_unsafe.rs:9:13
+  |
+9 |     let _ = p.peek_mut(); // ERROR: call to unsafe function is unsafe and requires unsafe block
+  |             ^^^^^^^^^^^^ call to unsafe function
+  |
+  = note: consult the function's documentation for information on how to avoid undefined behavior

--- a/lender/tests/test_adapters_chunk.rs
+++ b/lender/tests/test_adapters_chunk.rs
@@ -42,7 +42,8 @@ fn test_peekable_peek_mut() {
     let mut peekable = VecLender::new(vec![1, 2, 3]).peekable();
 
     // peek_mut returns a mutable reference to the lend
-    assert!(peekable.peek_mut().is_some());
+    // SAFETY: the peeked reference is only inspected, never moved out or overwritten to escape.
+    assert!(unsafe { peekable.peek_mut() }.is_some());
     assert_eq!(peekable.next(), Some(&1));
     assert_eq!(peekable.next(), Some(&2));
 }

--- a/lender/tests/test_fallible_adapters.rs
+++ b/lender/tests/test_fallible_adapters.rs
@@ -80,7 +80,8 @@ fn test_fallible_peekable_adapter() {
     assert_eq!(peekable.next().unwrap(), Some(2));
 
     // Test peek_mut
-    if let Some(val) = peekable.peek_mut().unwrap() {
+    // SAFETY: `val` is written through and dropped within this scope; the lend never escapes.
+    if let Some(val) = unsafe { peekable.peek_mut() }.unwrap() {
         *val = 100;
     }
     assert_eq!(peekable.next().unwrap(), Some(100));

--- a/lender/tests/test_fallible_methods.rs
+++ b/lender/tests/test_fallible_methods.rs
@@ -405,7 +405,8 @@ fn test_fallible_peekable_peek_mut() {
     let fallible: lender::IntoFallible<_> = VecLender::new(vec![1, 2, 3]).into_fallible();
     let mut peekable = fallible.peekable();
     // peek_mut to store a value and get mutable reference
-    let peeked = peekable.peek_mut().unwrap();
+    // SAFETY: `peeked` is only compared below and dropped before `peekable` is used again.
+    let peeked = unsafe { peekable.peek_mut() }.unwrap();
     assert_eq!(peeked, Some(&mut &1));
 }
 


### PR DESCRIPTION
Fixes a set of soundness, correctness, panic, and documentation bugs found while reviewing the crate. Each fix is its own commit and ships with a regression test in the same commit; every fix is applied to both the `adapters`/`sources` version and its `fallible_*` twin.

## Soundness
- **`peekable`: make `peek_mut` `unsafe`.** `Peekable::peek_mut` / `FalliblePeekable::peek_mut` returned `Option<&mut Lend<'this, L>>` with the lender's full storage lifetime, so safe code could copy out a lend that outlives the `&mut self` borrow (a `Peekable<'static, _>` yields a dangling reference). There is no sound *safe* signature, so both are now `unsafe fn` with a `# Safety` contract; a trybuild case proves the safe call is rejected (E0133).
- **`peekable`/`flatten`: drop the cached lend before freeing the lender allocation.** `into_inner`/`count`/`into_parts` moved the `AliasableBox<L>` out (freeing `L`) while the sibling `MaybeDangling` cache still held a lend/sub-lender borrowing into it, dropping that cache afterward — a use-after-free on drop. The cache is now cleared while the box is alive.

## Correctness
- **`step_by`: `nth` off-by-one on a fresh `StepBy`.** `step_by(2).nth(1)` returned index 1 instead of 2; the first element is now consumed before decrementing `n`, matching `std::iter::StepBy`.
- **`fuse`: `last()` did not set the fused flag.** Since `last()` drives the inner lender to `None`, a non-fused inner could resurrect on a later `next()`; the flag is now set.
- **`take_while`: inner-`None` was not terminal** despite the unconditional `FusedLender`/`FusedFallibleLender` impl; the done flag is now set on the inner-`None` path.
- **`take`: zero-width back operations corrupted the inner lender.** `advance_back_by(0)` trimmed the tail and `take(0).nth_back(_)` drained the inner lender (unlike `next_back`); `advance_back_by(0)` is now a no-op and `nth_back` is guarded with `self.n != 0`.

## Panics
- **`chunky`: `nth` overflow panic.** The exhaust branch did `len.checked_mul(chunk_size).expect(...)`, panicking for an `ExactSizeLender` with `len()` near `usize::MAX`; it now uses `saturating_mul` (the product only feeds `advance_by`).
- **`from_iter_ref`: double-borrow panic/deadlock.** `next`/`nth`/`next_back`/`nth_back` ran `self.current = self.iter.next()` with the previous item still owned, so an iterator whose items hold an exclusive borrow/guard (`RefMut`, `MutexGuard`) re-acquired the same resource; `self.current` is now cleared before fetching, as `last()` already did.

## Docs
- **`next_chunk`: corrected the doc** that claimed it "is equivalent to cloning the lender and calling `take`"; it borrows `&mut self` and advances the original lender.

## Testing
`cargo test -p lender` passes: 34 lib unit tests, all integration suites, the trybuild `fail` harness, and 214 doctests. `cargo build` and `cargo clippy -p lender --all-targets -- -D warnings` are clean. The two soundness fixes are correct by construction; Miri validation of them is left for CI.
